### PR TITLE
Receipt scanning: snap a photo, Gemini extracts date/amount/description

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,42 +3,43 @@
 ## Phase 1: Data Persistence (GCP Firestore)
 Store user data so it survives across sessions and devices.
 
-- [ ] **Add Firestore to platform-infra** — enable Firestore API, create database, grant runtime SA access
-- [ ] **User data model** — design Firestore collections: `users/{uid}/expenses`, `users/{uid}/investments`
-- [ ] **Save expenses to Firestore** — persist on add/remove, load on page visit
-- [ ] **Save investments to Firestore** — persist on add/remove, load on page visit
-- [ ] **Link auth to Firestore** — use Google OAuth UID as Firestore document key
-- [ ] **Loading states** — show skeleton/spinner while fetching data from Firestore
+- [x] **Add Firestore to platform-infra** — enable Firestore API, create database, grant runtime SA access
+- [x] **User data model** — design Firestore collections: `users/{uid}/expenses`, `users/{uid}/investments`
+- [x] **Save expenses to Firestore** — persist on add/remove, load on page visit
+- [x] **Save investments to Firestore** — persist on add/remove, load on page visit
+- [x] **Link auth to Firestore** — use Google OAuth UID as Firestore document key
+- [x] **Loading states** — show skeleton/spinner while fetching data from Firestore
 
 ## Phase 2: Gemini-Powered Advice
 Replace static rule-based assessments with Gemini AI analysis.
 
-- [ ] **Enable Vertex AI API** — add to platform-infra, store API key in Secret Manager
-- [ ] **Tax advice API route** — `/api/tax/advice` sends expense data to Gemini, returns personalised tax strategy
-- [ ] **Investment advice API route** — `/api/investments/advice` sends portfolio data to Gemini, returns allocation and strategy recommendations
-- [ ] **Prompt engineering** — craft system prompts for Australian tax context (ATO rules, CGT, negative gearing, super contributions, EOFY strategies)
-- [ ] **Streaming responses** — stream Gemini responses for better UX on longer analyses
-- [ ] **Replace static health assessment** — swap hardcoded diagnosis/prescription with Gemini-generated advice panel
-- [ ] **Conversation follow-up** — allow user to ask follow-up questions about the advice ("What if I salary sacrifice $500/month?")
+- [x] **Enable Vertex AI API** — add to platform-infra, store API key in Secret Manager
+- [x] **Tax advice API route** — `/api/tax/advice` sends expense data to Gemini, returns personalised tax strategy
+- [x] **Investment advice API route** — `/api/investments/advice` sends portfolio data to Gemini, returns allocation and strategy recommendations
+- [x] **Prompt engineering** — craft system prompts for Australian tax context (ATO rules, CGT, negative gearing, super contributions, EOFY strategies)
+- [x] **Streaming responses** — stream Gemini responses for better UX on longer analyses
+- [x] **Replace static health assessment** — swap hardcoded diagnosis/prescription with Gemini-generated advice panel
+- [x] **Conversation follow-up** — allow user to ask follow-up questions about the advice ("What if I salary sacrifice $500/month?")
 
 ## Phase 3: Smarter Data Input
 Reduce manual data entry.
 
-- [ ] **CSV/Excel import for expenses** — upload bank statement or accounting export, auto-map columns
-- [ ] **Gemini auto-categorisation** — send expense descriptions to Gemini to auto-assign ATO categories
+- [x] **CSV/Excel import for expenses** — upload bank statement or accounting export, auto-map columns
+- [x] **Cashflow CSV import** — transactional Date/Amount/Description/Type with owner tagging
+- [x] **Gemini auto-categorisation** — send expense descriptions to Gemini to auto-assign ATO + spending categories (Pub/Sub fan-out for large imports)
 - [ ] **Receipt scanning** — upload receipt photo, Gemini extracts date/amount/description
-- [ ] **Bulk edit expenses** — select multiple, change category, delete
-- [ ] **Recurring expenses** — mark an expense as recurring, auto-populate future months
+- [x] **Bulk edit expenses** — select multiple, change category, delete
+- [x] **Recurring expenses** — mark an expense as recurring, auto-populate future months
 - [ ] **Live share prices** — fetch current prices for ASX/US tickers via API to auto-update portfolio values
 
 ## Phase 4: Dashboard & Reporting
 Make the dashboard more useful.
 
-- [ ] **Dashboard summary widgets** — total deductions YTD, portfolio gain/loss, health scores
-- [ ] **Tax estimate calculator** — input gross income, calculate estimated tax refund/liability based on logged deductions
-- [ ] **Year-over-year comparison** — compare deductions and portfolio across financial years
+- [x] **Dashboard summary widgets** — total deductions YTD, portfolio gain/loss, health scores
+- [x] **Tax estimate calculator** — per-member estimated refund/liability based on logged deductions and salary
+- [x] **Year-over-year comparison** — compare deductions across financial years
 - [ ] **Export to PDF** — generate a summary report for accountant or personal records
-- [ ] **Charts** — pie chart for asset allocation, bar chart for deductions by category, line chart for portfolio value over time
+- [x] **Charts** — pie chart for asset allocation, bar/line charts for deductions and spending, line chart for portfolio over time
 
 ## Phase 5: Production Hardening
 Get the app production-ready.
@@ -46,8 +47,8 @@ Get the app production-ready.
 - [ ] **Custom domain** — move Cloud Run to us-central1 for domain mapping, or add GCP load balancer
 - [ ] **Add production OAuth redirect URIs** — update GCP OAuth client with production domain
 - [ ] **Rate limiting** — protect Gemini API routes from abuse
-- [ ] **Error boundaries** — graceful error handling on all pages
-- [ ] **Audit logging** — log Gemini API calls and costs
+- [x] **Error boundaries** — graceful error handling on all pages
+- [x] **Audit logging** — log Gemini API calls and costs
 - [ ] **Budget alerts** — set up GCP budget alerts for Gemini API spend
 - [ ] **E2E tests** — Playwright tests for login flow, add expense, add investment
 - [ ] **Mobile responsive** — verify and fix layout on mobile devices

--- a/functions/src/handlers/receipt-scan.ts
+++ b/functions/src/handlers/receipt-scan.ts
@@ -1,0 +1,132 @@
+import { HttpsError, onCall, type CallableRequest } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions/v2';
+import { getGeminiModel } from '../lib/gemini';
+import { requireUserEmail } from '../lib/auth';
+import { auditLog } from '../lib/audit';
+import { TAX_CATEGORIES, SPENDING_CATEGORIES } from '../lib/categorise';
+
+interface ReceiptScanData {
+  imageBase64: string;
+  mimeType: string;
+}
+
+interface ReceiptScanResult {
+  date?: string;
+  amount?: number;
+  description?: string;
+  category?: string;
+  spendingCategory?: string;
+  spendingSubCategory?: string;
+  merchant?: string;
+  notes?: string;
+  confidence?: 'high' | 'medium' | 'low';
+}
+
+const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/heic', 'image/heif']);
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+const RECEIPT_PROMPT = `You are an Australian receipt-extraction engine. Read the receipt image and return a single JSON object with these fields:
+
+- "date": purchase date in ISO format YYYY-MM-DD. If only a partial date is visible, infer the missing parts from context. Return null if absent.
+- "amount": the final total paid as a positive number (decimal, no currency symbol). Use the GST-inclusive total. Return null if absent.
+- "merchant": business / vendor name as printed on the receipt.
+- "description": a short human-friendly description for an expense register, e.g. "Coles — Groceries" or "Caltex Strathpine — Fuel". Combine the merchant with the dominant purchase type.
+- "category": ONE of these ATO tax-deduction categories (use exactly): ${TAX_CATEGORIES.join(', ')}. Pick "Other Deductions" if unsure or if the receipt is clearly personal.
+- "spendingCategory": ONE of these spending categories (use exactly): ${SPENDING_CATEGORIES.join(', ')}. Pick "Other" if unsure.
+- "spendingSubCategory": optional finer label (e.g. "Fuel", "Pharmacy", "Lunch"). Omit if not applicable.
+- "notes": optional short note for anything ambiguous (e.g. "Tip not included in total").
+- "confidence": "high" | "medium" | "low" — your confidence in the extracted total.
+
+Rules:
+- Return raw JSON only — no markdown fences, no commentary.
+- Use Australian context (AUD currency, ATO categories, AU date conventions).
+- If the image is not a receipt or cannot be read, return {"error": "Not a receipt"}.
+- The total must be a number, not a string. Strip any "$" or "AUD".`;
+
+export const expensesReceiptScan = onCall<ReceiptScanData>(
+  {
+    region: 'australia-southeast1',
+    serviceAccount: 'finance-doctor-functions@',
+    memory: '512MiB',
+    timeoutSeconds: 60,
+  },
+  async (request: CallableRequest<ReceiptScanData>): Promise<ReceiptScanResult> => {
+    const start = Date.now();
+    const email = requireUserEmail(request);
+    const { imageBase64, mimeType } = request.data ?? {};
+
+    if (!imageBase64 || !mimeType) {
+      throw new HttpsError('invalid-argument', 'imageBase64 and mimeType are required.');
+    }
+    if (!ALLOWED_MIME_TYPES.has(mimeType.toLowerCase())) {
+      throw new HttpsError('invalid-argument', `Unsupported mime type: ${mimeType}. Allowed: ${[...ALLOWED_MIME_TYPES].join(', ')}.`);
+    }
+
+    const cleanBase64 = imageBase64.replace(/^data:[^;]+;base64,/, '').trim();
+    const approxBytes = Math.floor((cleanBase64.length * 3) / 4);
+    if (approxBytes > MAX_IMAGE_BYTES) {
+      throw new HttpsError('invalid-argument', `Image is too large (${(approxBytes / 1024 / 1024).toFixed(1)} MB). Max ${MAX_IMAGE_BYTES / 1024 / 1024} MB.`);
+    }
+
+    const model = getGeminiModel();
+    let responseText = '';
+    try {
+      const result = await model.generateContent({
+        contents: [{
+          role: 'user',
+          parts: [
+            { inlineData: { mimeType, data: cleanBase64 } },
+            { text: 'Extract the receipt details as specified.' },
+          ],
+        }],
+        systemInstruction: { role: 'system', parts: [{ text: RECEIPT_PROMPT }] },
+      });
+      responseText = result.response?.candidates?.[0]?.content?.parts?.[0]?.text || '';
+    } catch (err) {
+      logger.error('Gemini receipt scan failed', { error: err instanceof Error ? err.message : err });
+      throw new HttpsError('internal', 'Receipt scan failed — please try again.');
+    }
+
+    const cleaned = responseText.replace(/```json?\n?/g, '').replace(/```/g, '').trim();
+    let parsed: Record<string, unknown> = {};
+    try {
+      parsed = JSON.parse(cleaned);
+    } catch {
+      logger.warn('Could not parse receipt JSON', { responseText });
+      throw new HttpsError('internal', 'Could not read the receipt — try a clearer photo.');
+    }
+
+    if (typeof parsed.error === 'string') {
+      throw new HttpsError('failed-precondition', parsed.error);
+    }
+
+    const out: ReceiptScanResult = {};
+    if (typeof parsed.date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(parsed.date)) out.date = parsed.date;
+    if (typeof parsed.amount === 'number' && Number.isFinite(parsed.amount) && parsed.amount > 0) out.amount = parsed.amount;
+    if (typeof parsed.merchant === 'string' && parsed.merchant.trim()) out.merchant = parsed.merchant.trim();
+    if (typeof parsed.description === 'string' && parsed.description.trim()) out.description = parsed.description.trim();
+    else if (out.merchant) out.description = out.merchant;
+    if (typeof parsed.category === 'string' && TAX_CATEGORIES.includes(parsed.category)) out.category = parsed.category;
+    else out.category = 'Other Deductions';
+    if (typeof parsed.spendingCategory === 'string' && SPENDING_CATEGORIES.includes(parsed.spendingCategory)) out.spendingCategory = parsed.spendingCategory;
+    else out.spendingCategory = 'Other';
+    if (typeof parsed.spendingSubCategory === 'string' && parsed.spendingSubCategory.trim()) out.spendingSubCategory = parsed.spendingSubCategory.trim();
+    if (typeof parsed.notes === 'string' && parsed.notes.trim()) out.notes = parsed.notes.trim();
+    if (parsed.confidence === 'high' || parsed.confidence === 'medium' || parsed.confidence === 'low') {
+      out.confidence = parsed.confidence;
+    }
+
+    auditLog({
+      endpoint: 'expensesReceiptScan',
+      email,
+      durationMs: Date.now() - start,
+      geminiCalled: true,
+      mimeType,
+      imageBytes: approxBytes,
+      extractedAmount: out.amount ?? null,
+      confidence: out.confidence ?? null,
+    });
+
+    return out;
+  },
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,6 +4,7 @@ export { taxAdvice } from './handlers/tax-advice';
 export { investmentsAdvice } from './handlers/investments-advice';
 export { expensesAdvice } from './handlers/expenses-advice';
 export { expensesImport } from './handlers/expenses-import';
+export { expensesReceiptScan } from './handlers/receipt-scan';
 export { expensesMigrate } from './handlers/expenses-migrate';
 export { expensesReanalyse } from './handlers/expenses-reanalyse';
 export { expensesCategoriseWorker } from './handlers/expenses-categorise-worker';

--- a/src/components/data-management.tsx
+++ b/src/components/data-management.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/lib/functions-client';
 import { listExpenses, watchPendingCategorisation } from '@/lib/expenses-repo';
 import { listFamilyMembers } from '@/lib/family-members-repo';
+import ReceiptScan from '@/components/receipt-scan';
 
 const CATEGORIES = [
   'Work from Home',
@@ -184,6 +185,8 @@ export default function DataManagement() {
 
   return (
     <>
+      <ReceiptScan familyMembers={familyMembers} onSaved={fetchExpenses} />
+
       <Panel className="mb-3">
         <PanelHeader noButton>
           <div className="d-flex flex-wrap align-items-center gap-2">

--- a/src/components/receipt-scan.tsx
+++ b/src/components/receipt-scan.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { useState } from 'react';
+import { Panel, PanelHeader, PanelBody } from '@/components/panel/panel';
+import type { FamilyMember } from '@/lib/types';
+import { scanReceipt, type ReceiptScanResult } from '@/lib/functions-client';
+import { addExpenses } from '@/lib/expenses-repo';
+
+const TAX_CATEGORIES = [
+  'Work from Home',
+  'Vehicle & Travel',
+  'Clothing & Laundry',
+  'Self-Education',
+  'Tools & Equipment',
+  'Professional Memberships',
+  'Phone & Internet',
+  'Donations',
+  'Investment Expenses',
+  'Investment Property',
+  'Other Deductions',
+];
+
+const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/heic', 'image/heif'];
+const MAX_BYTES = 5 * 1024 * 1024;
+
+function getFinancialYear(date: string): string {
+  const [yearStr, monthStr] = date.split('-');
+  const year = parseInt(yearStr);
+  const month = parseInt(monthStr);
+  if (Number.isNaN(year) || Number.isNaN(month)) return '';
+  if (month >= 7) return `${year}-${year + 1}`;
+  return `${year - 1}-${year}`;
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') return reject(new Error('Unexpected reader result'));
+      const comma = result.indexOf(',');
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error || new Error('Could not read file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+interface DraftExpense {
+  date: string;
+  description: string;
+  amount: string;
+  category: string;
+  owner: string;
+  nonDeductible: boolean;
+  notes?: string;
+  confidence?: 'high' | 'medium' | 'low';
+}
+
+interface Props {
+  familyMembers: FamilyMember[];
+  onSaved?: () => void;
+}
+
+export default function ReceiptScan({ familyMembers, onSaved }: Props) {
+  const [open, setOpen] = useState(false);
+  const [scanning, setScanning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [draft, setDraft] = useState<DraftExpense | null>(null);
+  const [scanResult, setScanResult] = useState<ReceiptScanResult | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [savedMessage, setSavedMessage] = useState<string | null>(null);
+
+  const reset = () => {
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setPreviewUrl(null);
+    setDraft(null);
+    setScanResult(null);
+    setError(null);
+  };
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+
+    if (!ALLOWED_TYPES.includes(file.type.toLowerCase())) {
+      setError(`Unsupported file type: ${file.type || 'unknown'}. Use JPEG, PNG, WEBP, or HEIC.`);
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      setError(`File is ${(file.size / 1024 / 1024).toFixed(1)} MB — limit is ${MAX_BYTES / 1024 / 1024} MB.`);
+      return;
+    }
+
+    reset();
+    setSavedMessage(null);
+    setScanning(true);
+    setPreviewUrl(URL.createObjectURL(file));
+
+    try {
+      const base64 = await fileToBase64(file);
+      const result = await scanReceipt(base64, file.type);
+      setScanResult(result);
+      const ownerDefault = familyMembers.length === 1 ? familyMembers[0].name : '';
+      setDraft({
+        date: result.date || '',
+        description: result.description || result.merchant || '',
+        amount: typeof result.amount === 'number' ? result.amount.toFixed(2) : '',
+        category: result.category || 'Other Deductions',
+        owner: ownerDefault,
+        nonDeductible: false,
+        notes: result.notes,
+        confidence: result.confidence,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Receipt scan failed.');
+    } finally {
+      setScanning(false);
+    }
+  };
+
+  const updateDraft = <K extends keyof DraftExpense>(key: K, value: DraftExpense[K]) => {
+    setDraft(prev => prev ? { ...prev, [key]: value } : prev);
+  };
+
+  const canSave = draft && draft.date && draft.description.trim() && Number(draft.amount) > 0;
+
+  const handleSave = async () => {
+    if (!draft || !canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const fy = getFinancialYear(draft.date);
+      if (!fy) throw new Error('Invalid date — use YYYY-MM-DD.');
+      await addExpenses([{
+        date: draft.date,
+        description: draft.description.trim(),
+        amount: Number(Number(draft.amount).toFixed(2)),
+        category: draft.category,
+        ...(scanResult?.spendingCategory ? { spendingCategory: scanResult.spendingCategory } : {}),
+        ...(scanResult?.spendingSubCategory ? { spendingSubCategory: scanResult.spendingSubCategory } : {}),
+        financialYear: fy,
+        ...(draft.owner ? { owner: draft.owner } : {}),
+        ...(draft.nonDeductible ? { nonDeductible: true } : {}),
+      }]);
+      setSavedMessage(`Saved $${Number(draft.amount).toFixed(2)} — ${draft.description.trim()}.`);
+      reset();
+      onSaved?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save expense.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Panel className="mb-3">
+      <PanelHeader noButton>
+        <div className="d-flex flex-wrap align-items-center gap-2">
+          <span><i className="fa fa-camera me-2"></i>Scan Receipt</span>
+          <button className="btn btn-sm btn-outline-primary ms-sm-auto" onClick={() => { setOpen(o => !o); reset(); setSavedMessage(null); }}>
+            {open ? <><i className="fa fa-times me-1"></i>Close</> : <><i className="fa fa-camera me-1"></i>Scan</>}
+          </button>
+        </div>
+      </PanelHeader>
+      {open && (
+        <PanelBody>
+          <p className="text-muted small mb-3">
+            Snap or upload a receipt photo and Dr Finance will read it. Review the extracted date, total, and category, then save as a single expense. Supports JPEG, PNG, WEBP, and HEIC up to {MAX_BYTES / 1024 / 1024} MB.
+          </p>
+
+          {savedMessage && (
+            <div className="alert alert-success alert-dismissible py-2 small mb-3" role="alert">
+              <i className="fa fa-check-circle me-1"></i>{savedMessage}
+              <button type="button" className="btn-close btn-sm" aria-label="Dismiss" onClick={() => setSavedMessage(null)}></button>
+            </div>
+          )}
+
+          {error && (
+            <div className="alert alert-danger alert-dismissible py-2 small mb-3" role="alert">
+              <i className="fa fa-triangle-exclamation me-1"></i>{error}
+              <button type="button" className="btn-close btn-sm" aria-label="Dismiss" onClick={() => setError(null)}></button>
+            </div>
+          )}
+
+          {!draft && !scanning && (
+            <div>
+              <label className="btn btn-outline-primary" htmlFor="receipt-upload">
+                <i className="fa fa-upload me-1"></i>Choose Receipt
+              </label>
+              <input
+                id="receipt-upload"
+                type="file"
+                accept="image/jpeg,image/png,image/webp,image/heic,image/heif"
+                capture="environment"
+                className="d-none"
+                onChange={handleFile}
+              />
+            </div>
+          )}
+
+          {scanning && (
+            <div className="d-flex align-items-center text-muted small">
+              <i className="fa fa-spinner fa-spin me-2"></i>Reading the receipt with Dr Finance Vision...
+            </div>
+          )}
+
+          {draft && !scanning && (
+            <div className="row g-3">
+              <div className="col-md-4">
+                {previewUrl && (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={previewUrl} alt="Receipt preview" className="img-fluid rounded border" />
+                )}
+                {draft.confidence && (
+                  <div className="mt-2">
+                    <span className={`badge ${draft.confidence === 'high' ? 'bg-success' : draft.confidence === 'medium' ? 'bg-warning text-dark' : 'bg-secondary'}`}>
+                      <i className="fa fa-robot me-1"></i>AI confidence: {draft.confidence}
+                    </span>
+                  </div>
+                )}
+                {draft.notes && (
+                  <div className="alert alert-info py-2 mt-2 small mb-0">
+                    <i className="fa fa-circle-info me-1"></i>{draft.notes}
+                  </div>
+                )}
+              </div>
+              <div className="col-md-8">
+                <div className="row g-2">
+                  <div className="col-md-6">
+                    <label className="form-label small text-muted mb-1">Date</label>
+                    <input type="date" className="form-control form-control-sm" value={draft.date} onChange={e => updateDraft('date', e.target.value)} required />
+                  </div>
+                  <div className="col-md-6">
+                    <label className="form-label small text-muted mb-1">Amount (AUD)</label>
+                    <input type="number" step="0.01" min="0.01" className="form-control form-control-sm" value={draft.amount} onChange={e => updateDraft('amount', e.target.value)} required />
+                  </div>
+                  <div className="col-12">
+                    <label className="form-label small text-muted mb-1">Description</label>
+                    <input type="text" className="form-control form-control-sm" value={draft.description} onChange={e => updateDraft('description', e.target.value)} required />
+                  </div>
+                  <div className="col-md-6">
+                    <label className="form-label small text-muted mb-1">Tax Category</label>
+                    <select className="form-select form-select-sm" value={draft.category} onChange={e => updateDraft('category', e.target.value)}>
+                      {TAX_CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+                    </select>
+                  </div>
+                  {familyMembers.length > 0 && (
+                    <div className="col-md-6">
+                      <label className="form-label small text-muted mb-1">Owner</label>
+                      <select className="form-select form-select-sm" value={draft.owner} onChange={e => updateDraft('owner', e.target.value)}>
+                        <option value="">Unassigned</option>
+                        {familyMembers.map(m => <option key={m.id} value={m.name}>{m.name}</option>)}
+                      </select>
+                    </div>
+                  )}
+                  <div className="col-12">
+                    <div className="form-check">
+                      <input className="form-check-input" type="checkbox" id="receipt-nondeductible" checked={draft.nonDeductible} onChange={e => updateDraft('nonDeductible', e.target.checked)} />
+                      <label className="form-check-label small" htmlFor="receipt-nondeductible">
+                        Personal — not tax deductible
+                      </label>
+                    </div>
+                  </div>
+                  {scanResult?.spendingCategory && scanResult.spendingCategory !== 'Other' && (
+                    <div className="col-12">
+                      <span className="text-muted small">
+                        <i className="fa fa-tag me-1"></i>Spending category: <strong>{scanResult.spendingCategory}</strong>
+                        {scanResult.spendingSubCategory && <> / {scanResult.spendingSubCategory}</>}
+                      </span>
+                    </div>
+                  )}
+                </div>
+                <div className="d-flex gap-2 mt-3">
+                  <button className="btn btn-sm btn-success" disabled={!canSave || saving} onClick={handleSave}>
+                    {saving ? <><i className="fa fa-spinner fa-spin me-1"></i>Saving...</> : <><i className="fa fa-check me-1"></i>Save Expense</>}
+                  </button>
+                  <button className="btn btn-sm btn-outline-secondary" onClick={reset} disabled={saving}>
+                    <i className="fa fa-times me-1"></i>Discard
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </PanelBody>
+      )}
+    </Panel>
+  );
+}

--- a/src/lib/functions-client.ts
+++ b/src/lib/functions-client.ts
@@ -188,3 +188,24 @@ export async function reanalyseExpenses(payload: { financialYear?: string; type?
   const res = await fn(payload);
   return res.data;
 }
+
+export interface ReceiptScanResult {
+  date?: string;
+  amount?: number;
+  description?: string;
+  merchant?: string;
+  category?: string;
+  spendingCategory?: string;
+  spendingSubCategory?: string;
+  notes?: string;
+  confidence?: 'high' | 'medium' | 'low';
+}
+
+export async function scanReceipt(imageBase64: string, mimeType: string): Promise<ReceiptScanResult> {
+  if (guest.isGuest()) {
+    throw new Error('Receipt scanning is disabled in Guest mode — sign in with Google to use Dr Finance Vision.');
+  }
+  const fn = httpsCallable<{ imageBase64: string; mimeType: string }, ReceiptScanResult>(assertFunctions(), 'expensesReceiptScan');
+  const res = await fn({ imageBase64, mimeType });
+  return res.data;
+}


### PR DESCRIPTION
Adds an `expensesReceiptScan` callable that sends an inline-encoded image
to Gemini and parses the receipt into a single expense (date, total,
merchant, ATO + spending category, optional sub-category and notes).

Surfaces a "Scan Receipt" panel above the CSV importer in Settings:
file/camera capture, live preview, editable extracted fields, and a
one-click save into Firestore via the existing addExpenses path. Guest
mode is gated with a clear message.

Also refreshes BACKLOG.md to reflect what's actually shipped — Phase 1
and Phase 2 are done, plus most of Phase 3-4. Receipt scanning was the
next un-done item in Phase 3.