### PR TITLE
Live share prices: refresh ASX/US/crypto holdings via Yahoo Finance

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -27,10 +27,10 @@ Reduce manual data entry.
 - [x] **CSV/Excel import for expenses** — upload bank statement or accounting export, auto-map columns
 - [x] **Cashflow CSV import** — transactional Date/Amount/Description/Type with owner tagging
 - [x] **Gemini auto-categorisation** — send expense descriptions to Gemini to auto-assign ATO + spending categories (Pub/Sub fan-out for large imports)
-- [ ] **Receipt scanning** — upload receipt photo, Gemini extracts date/amount/description
+- [x] **Receipt scanning** — upload receipt photo, Gemini extracts date/amount/description
 - [x] **Bulk edit expenses** — select multiple, change category, delete
 - [x] **Recurring expenses** — mark an expense as recurring, auto-populate future months
-- [ ] **Live share prices** — fetch current prices for ASX/US tickers via API to auto-update portfolio values
+- [x] **Live share prices** — fetch current prices for ASX/US tickers via API to auto-update portfolio values
 
 ## Phase 4: Dashboard & Reporting
 Make the dashboard more useful.

--- a/functions/src/handlers/investments-refresh-prices.ts
+++ b/functions/src/handlers/investments-refresh-prices.ts
@@ -1,0 +1,234 @@
+import { HttpsError, onCall, type CallableRequest } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions/v2';
+import { getDb } from '../lib/firestore';
+import { requireUserEmail } from '../lib/auth';
+import { auditLog } from '../lib/audit';
+import type { Investment } from '../lib/types';
+
+interface RefreshPricesData {
+  ids?: string[];
+}
+
+interface PriceUpdate {
+  id: string;
+  ticker: string;
+  ok: boolean;
+  price?: number;
+  currency?: string;
+  fxToAud?: number;
+  currentValue?: number;
+  previousValue?: number;
+  updatedAt?: string;
+  error?: string;
+}
+
+interface RefreshPricesResult {
+  total: number;
+  updated: number;
+  failed: number;
+  results: PriceUpdate[];
+}
+
+const TRADED_TYPES = new Set([
+  'Australian Shares',
+  'International Shares',
+  'ETFs',
+  'Cryptocurrency',
+]);
+
+const MAX_TICKERS_PER_CALL = 100;
+const YAHOO_BASE = 'https://query1.finance.yahoo.com/v8/finance/chart';
+const FETCH_TIMEOUT_MS = 10_000;
+
+interface YahooQuote {
+  price: number;
+  currency: string;
+}
+
+async function fetchYahooQuote(symbol: string): Promise<YahooQuote> {
+  const url = `${YAHOO_BASE}/${encodeURIComponent(symbol)}?interval=1d&range=1d`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; FinanceDoctor/1.0; +https://finance-doctor.app)',
+        Accept: 'application/json',
+      },
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+  if (!res.ok) throw new Error(`Yahoo returned HTTP ${res.status}`);
+  const json = await res.json() as {
+    chart?: {
+      result?: { meta?: { regularMarketPrice?: number; currency?: string } }[];
+      error?: { description?: string } | null;
+    };
+  };
+  if (json?.chart?.error) {
+    throw new Error(json.chart.error.description || 'Yahoo error');
+  }
+  const meta = json?.chart?.result?.[0]?.meta;
+  if (!meta) throw new Error('No quote data');
+  const price = meta.regularMarketPrice;
+  if (typeof price !== 'number' || !Number.isFinite(price) || price <= 0) {
+    throw new Error('Invalid price');
+  }
+  return { price, currency: (meta.currency || 'USD').toUpperCase() };
+}
+
+function normaliseTicker(raw: string): string {
+  return raw.trim().toUpperCase();
+}
+
+export const investmentsRefreshPrices = onCall<RefreshPricesData>(
+  {
+    region: 'australia-southeast1',
+    serviceAccount: 'finance-doctor-functions@',
+    memory: '256MiB',
+    timeoutSeconds: 60,
+  },
+  async (request: CallableRequest<RefreshPricesData>): Promise<RefreshPricesResult> => {
+    const start = Date.now();
+    const email = requireUserEmail(request);
+    const idFilter = request.data?.ids;
+
+    const db = getDb();
+    const col = db.collection('users').doc(email).collection('investments');
+    const snap = await col.get();
+    const all = snap.docs.map(d => ({ id: d.id, ...d.data() } as Investment));
+
+    const eligible = all.filter(inv => {
+      if (!inv.ticker || !inv.ticker.trim()) return false;
+      if (!TRADED_TYPES.has(inv.type)) return false;
+      if (typeof inv.units !== 'number' || inv.units <= 0) return false;
+      if (idFilter && idFilter.length > 0) return idFilter.includes(inv.id);
+      return true;
+    });
+
+    if (eligible.length === 0) {
+      auditLog({
+        endpoint: 'investmentsRefreshPrices',
+        email,
+        durationMs: Date.now() - start,
+        geminiCalled: false,
+        considered: all.length,
+        eligible: 0,
+        updated: 0,
+        failed: 0,
+      });
+      return { total: 0, updated: 0, failed: 0, results: [] };
+    }
+    if (eligible.length > MAX_TICKERS_PER_CALL) {
+      throw new HttpsError(
+        'invalid-argument',
+        `Too many tickers (${eligible.length}). Limit is ${MAX_TICKERS_PER_CALL} per refresh.`,
+      );
+    }
+
+    // De-dup tickers + collect non-AUD currencies for FX lookup.
+    const tickers = Array.from(new Set(eligible.map(i => normaliseTicker(i.ticker!))));
+    const quoteResults = await Promise.allSettled(tickers.map(t => fetchYahooQuote(t)));
+    const quoteMap = new Map<string, YahooQuote | { error: string }>();
+    tickers.forEach((t, i) => {
+      const r = quoteResults[i];
+      if (r.status === 'fulfilled') quoteMap.set(t, r.value);
+      else quoteMap.set(t, { error: r.reason instanceof Error ? r.reason.message : String(r.reason) });
+    });
+
+    const neededFx = new Set<string>();
+    for (const q of quoteMap.values()) {
+      if ('price' in q && q.currency && q.currency !== 'AUD') neededFx.add(q.currency);
+    }
+    const fxRates = new Map<string, number>([['AUD', 1]]);
+    if (neededFx.size > 0) {
+      const fxList = [...neededFx];
+      const fxResults = await Promise.allSettled(fxList.map(c => fetchYahooQuote(`${c}AUD=X`)));
+      fxList.forEach((c, i) => {
+        const r = fxResults[i];
+        if (r.status === 'fulfilled') fxRates.set(c, r.value.price);
+        else logger.warn('FX fetch failed', { currency: c, error: r.reason });
+      });
+    }
+
+    const updates: PriceUpdate[] = [];
+    const writeBatch = db.batch();
+    const nowIso = new Date().toISOString();
+    let updatedCount = 0;
+    let failedCount = 0;
+
+    for (const inv of eligible) {
+      const ticker = normaliseTicker(inv.ticker!);
+      const quote = quoteMap.get(ticker);
+      if (!quote || 'error' in quote) {
+        failedCount++;
+        updates.push({
+          id: inv.id,
+          ticker,
+          ok: false,
+          error: quote && 'error' in quote ? quote.error : 'Unknown error',
+        });
+        continue;
+      }
+      const fx = fxRates.get(quote.currency);
+      if (typeof fx !== 'number' || !Number.isFinite(fx) || fx <= 0) {
+        failedCount++;
+        updates.push({
+          id: inv.id,
+          ticker,
+          ok: false,
+          price: quote.price,
+          currency: quote.currency,
+          error: `No AUD FX rate available for ${quote.currency}`,
+        });
+        continue;
+      }
+      const audPrice = quote.price * fx;
+      const newValue = Number((audPrice * (inv.units || 0)).toFixed(2));
+      const prevValue = inv.currentValue;
+      writeBatch.update(col.doc(inv.id), {
+        currentValue: newValue,
+        lastPrice: Number(audPrice.toFixed(4)),
+        lastPriceCurrency: quote.currency,
+        lastPriceUpdate: nowIso,
+      });
+      updatedCount++;
+      updates.push({
+        id: inv.id,
+        ticker,
+        ok: true,
+        price: quote.price,
+        currency: quote.currency,
+        fxToAud: fx,
+        currentValue: newValue,
+        previousValue: prevValue,
+        updatedAt: nowIso,
+      });
+    }
+
+    if (updatedCount > 0) await writeBatch.commit();
+
+    auditLog({
+      endpoint: 'investmentsRefreshPrices',
+      email,
+      durationMs: Date.now() - start,
+      geminiCalled: false,
+      considered: all.length,
+      eligible: eligible.length,
+      updated: updatedCount,
+      failed: failedCount,
+      uniqueTickers: tickers.length,
+      fxLookups: neededFx.size,
+    });
+
+    return {
+      total: eligible.length,
+      updated: updatedCount,
+      failed: failedCount,
+      results: updates,
+    };
+  },
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,6 +5,7 @@ export { investmentsAdvice } from './handlers/investments-advice';
 export { expensesAdvice } from './handlers/expenses-advice';
 export { expensesImport } from './handlers/expenses-import';
 export { expensesReceiptScan } from './handlers/receipt-scan';
+export { investmentsRefreshPrices } from './handlers/investments-refresh-prices';
 export { expensesMigrate } from './handlers/expenses-migrate';
 export { expensesReanalyse } from './handlers/expenses-reanalyse';
 export { expensesCategoriseWorker } from './handlers/expenses-categorise-worker';

--- a/functions/src/lib/types.ts
+++ b/functions/src/lib/types.ts
@@ -77,6 +77,10 @@ export interface Investment {
   couponRate?: number;
   maturityDate?: string;
   monthlyRepayment?: number;
+  ticker?: string;
+  lastPrice?: number;
+  lastPriceCurrency?: string;
+  lastPriceUpdate?: string;
 }
 
 export interface ChatMessage {

--- a/src/app/investments/page.tsx
+++ b/src/app/investments/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Panel, PanelHeader, PanelBody } from '@/components/panel/panel';
 import type { Investment, FamilyMember, Expense } from '@/lib/types';
-import { adviceChatGet, adviceChatPut, streamInvestmentsAdvice } from '@/lib/functions-client';
+import { adviceChatGet, adviceChatPut, streamInvestmentsAdvice, refreshInvestmentPrices, type RefreshPricesResponse } from '@/lib/functions-client';
 import { listInvestments, addInvestment, updateInvestment, deleteInvestment } from '@/lib/investments-repo';
 import { listExpenses, updateExpense } from '@/lib/expenses-repo';
 import AllocationChart from '@/components/allocation-chart';
@@ -104,6 +104,7 @@ interface FormState {
   units: string;
   buyPricePerUnit: string;
   currentValue: string;
+  ticker: string;
   // Property
   propertyType: string;
   purchasePrice: string;
@@ -125,11 +126,18 @@ interface FormState {
 
 const EMPTY_FORM: FormState = {
   name: '', type: INVESTMENT_TYPES[0], owner: '',
-  units: '', buyPricePerUnit: '', currentValue: '',
+  units: '', buyPricePerUnit: '', currentValue: '', ticker: '',
   propertyType: 'Investment', purchasePrice: '', address: '', rentalIncomeMonthly: '', liability: '', monthlyRepayment: '',
   amount: '', interestRate: '',
   faceValue: '', couponRate: '', maturityDate: '',
   balance: '', employerContribution: '',
+};
+
+const TICKER_PLACEHOLDERS: Record<string, string> = {
+  'Australian Shares': 'e.g. CBA.AX',
+  'International Shares': 'e.g. AAPL',
+  'ETFs': 'e.g. VAS.AX, VTI',
+  'Cryptocurrency': 'e.g. BTC-AUD',
 };
 
 function buildInvestment(form: FormState): Investment {
@@ -138,7 +146,15 @@ function buildInvestment(form: FormState): Investment {
   if (TRADED_TYPES.includes(form.type)) {
     const units = parseFloat(form.units);
     const buyPrice = parseFloat(form.buyPricePerUnit);
-    return { ...base, units, buyPricePerUnit: buyPrice, costBasis: units * buyPrice, currentValue: parseFloat(form.currentValue) };
+    const ticker = form.ticker.trim().toUpperCase();
+    return {
+      ...base,
+      units,
+      buyPricePerUnit: buyPrice,
+      costBasis: units * buyPrice,
+      currentValue: parseFloat(form.currentValue),
+      ...(ticker ? { ticker } : {}),
+    };
   }
   if (form.type === 'Property') {
     const pp = parseFloat(form.purchasePrice);
@@ -208,6 +224,19 @@ function TypeSpecificFields({ form, setForm }: { form: FormState; setForm: (f: F
         <div className="col-12">
           <label className="form-label text-muted small mb-1">Current total value</label>
           <CurrencyInput placeholder="0.00" value={form.currentValue} onChange={v => setForm({ ...form, currentValue: v })} required />
+        </div>
+        <div className="col-12">
+          <label className="form-label text-muted small mb-1">Ticker (optional)</label>
+          <input
+            type="text"
+            className="form-control"
+            placeholder={TICKER_PLACEHOLDERS[type] || 'e.g. AAPL'}
+            value={form.ticker}
+            onChange={e => setForm({ ...form, ticker: e.target.value })}
+            autoCapitalize="characters"
+            autoComplete="off"
+          />
+          <div className="form-text small">Yahoo Finance symbol — ASX needs <code>.AX</code>, crypto uses <code>BTC-AUD</code>. Set this to refresh the price live.</div>
         </div>
       </>
     );
@@ -370,6 +399,22 @@ function estimateCgt(inv: Investment, familyMembers: FamilyMember[]): { amount: 
   return { amount: cgt, label: `$${cgt.toLocaleString('en-AU', { minimumFractionDigits: 2 })}` };
 }
 
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return '';
+  const diffMs = Date.now() - then;
+  if (diffMs < 0) return 'just now';
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 45) return 'just now';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  return new Date(iso).toLocaleDateString('en-AU');
+}
+
 function formatDetail(inv: Investment): string {
   if (TRADED_TYPES.includes(inv.type) && inv.units) return `${inv.units} units @ $${inv.buyPricePerUnit?.toFixed(2)}`;
   if (inv.type === 'Property') {
@@ -403,6 +448,9 @@ export default function InvestmentsPage() {
   const [expandedInvCategories, setExpandedInvCategories] = useState<Set<string>>(new Set());
   const [expandedInvSubs, setExpandedInvSubs] = useState<Set<string>>(new Set());
   const [mode, setMode] = useViewMode('viewMode.investments');
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshSummary, setRefreshSummary] = useState<RefreshPricesResponse | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
 
   const toggleInvestmentExpanded = (key: string) => {
     setExpandedInvestmentIds(prev => {
@@ -496,6 +544,7 @@ export default function InvestmentsPage() {
       f.units = String(inv.units || '');
       f.buyPricePerUnit = String(inv.buyPricePerUnit || '');
       f.currentValue = String(inv.currentValue);
+      f.ticker = inv.ticker || '';
     } else if (inv.type === 'Property') {
       f.propertyType = inv.propertyType || 'Investment';
       f.address = inv.address || '';
@@ -534,6 +583,36 @@ export default function InvestmentsPage() {
     await deleteInvestment(id);
     setInvestments(prev => prev.filter(i => i.id !== id));
   };
+
+  const refreshPrices = async (id?: string) => {
+    setRefreshing(true);
+    setRefreshError(null);
+    setRefreshSummary(null);
+    try {
+      const res = await refreshInvestmentPrices(id ? [id] : undefined);
+      setRefreshSummary(res);
+      if (res.updated > 0) {
+        const byId = new Map(res.results.filter(r => r.ok).map(r => [r.id, r]));
+        setInvestments(prev => prev.map(inv => {
+          const r = byId.get(inv.id);
+          if (!r) return inv;
+          return {
+            ...inv,
+            currentValue: r.currentValue ?? inv.currentValue,
+            lastPrice: r.price,
+            lastPriceCurrency: r.currency,
+            lastPriceUpdate: r.updatedAt,
+          };
+        }));
+      }
+    } catch (err) {
+      setRefreshError(err instanceof Error ? err.message : 'Could not refresh prices.');
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const tickerCount = investments.filter(i => i.ticker && TRADED_TYPES.includes(i.type) && (i.units || 0) > 0).length;
 
   const streamAdvice = async (history: { role: 'user' | 'model'; text: string }[], followUp?: string) => {
     setAdviceLoading(true);
@@ -1017,12 +1096,45 @@ export default function InvestmentsPage() {
             <PanelHeader noButton>
               <div className="d-flex flex-wrap align-items-center gap-2">
                 <span>Investments</span>
-                <button className="btn btn-success btn-sm ms-sm-auto" onClick={() => { if (showForm) cancelEdit(); else setShowForm(true); }}>
+                {tickerCount > 0 && (
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-primary ms-sm-auto"
+                    onClick={() => refreshPrices()}
+                    disabled={refreshing}
+                    title={`Refresh live prices for ${tickerCount} ticker${tickerCount === 1 ? '' : 's'}`}
+                  >
+                    {refreshing
+                      ? <><i className="fa fa-spinner fa-spin me-1"></i>Refreshing...</>
+                      : <><i className="fa fa-arrows-rotate me-1"></i>Refresh Prices</>}
+                  </button>
+                )}
+                <button
+                  className="btn btn-success btn-sm"
+                  style={tickerCount === 0 ? { marginLeft: 'auto' } : undefined}
+                  onClick={() => { if (showForm) cancelEdit(); else setShowForm(true); }}
+                >
                   {showForm ? <><i className="fa fa-times me-1"></i>Cancel</> : <><i className="fa fa-plus me-1"></i>Add Investment</>}
                 </button>
               </div>
             </PanelHeader>
             <PanelBody>
+              {refreshError && (
+                <div className="alert alert-danger alert-dismissible py-2 small mb-3" role="alert">
+                  <i className="fa fa-triangle-exclamation me-1"></i>{refreshError}
+                  <button type="button" className="btn-close btn-sm" aria-label="Dismiss" onClick={() => setRefreshError(null)}></button>
+                </div>
+              )}
+              {refreshSummary && (
+                <div className={`alert ${refreshSummary.failed === 0 ? 'alert-success' : 'alert-warning'} alert-dismissible py-2 small mb-3`} role="alert">
+                  <i className="fa fa-circle-info me-1"></i>
+                  Refreshed <strong>{refreshSummary.updated}</strong> of {refreshSummary.total} holdings.
+                  {refreshSummary.failed > 0 && (
+                    <> Failed: {refreshSummary.results.filter(r => !r.ok).map(r => `${r.ticker} (${r.error || 'unknown'})`).join(', ')}.</>
+                  )}
+                  <button type="button" className="btn-close btn-sm" aria-label="Dismiss" onClick={() => setRefreshSummary(null)}></button>
+                </div>
+              )}
               {showForm && (
                 <form onSubmit={handleSubmit} className="mb-3 p-3 bg-light rounded" style={{ maxWidth: '400px' }}>
                   <div className="mb-3">
@@ -1087,7 +1199,14 @@ export default function InvestmentsPage() {
                         const cgt = estimateCgt(inv, familyMembers);
                         return (
                           <tr key={inv.id}>
-                            <td className="fw-bold">{inv.name}</td>
+                            <td className="fw-bold">
+                              {inv.name}
+                              {inv.ticker && (
+                                <div className="text-muted small fw-normal">
+                                  <i className="fa fa-tag me-1" style={{ fontSize: '0.7rem' }}></i>{inv.ticker}
+                                </div>
+                              )}
+                            </td>
                             <td className="text-muted small">{inv.owner || '—'}</td>
                             <td>
                               <span className={`badge ${TYPE_COLORS[inv.type] || 'bg-secondary'}`}>
@@ -1098,7 +1217,15 @@ export default function InvestmentsPage() {
                             <td className="text-muted small">{formatDetail(inv)}</td>
                             <td className="text-end">${inv.costBasis.toLocaleString('en-AU', { minimumFractionDigits: 2 })}</td>
                             <td className="text-end">{inv.type === 'Property' && inv.liability ? `$${inv.liability.toLocaleString('en-AU', { minimumFractionDigits: 2 })}` : '—'}</td>
-                            <td className="text-end">${inv.currentValue.toLocaleString('en-AU', { minimumFractionDigits: 2 })}</td>
+                            <td className="text-end">
+                              ${inv.currentValue.toLocaleString('en-AU', { minimumFractionDigits: 2 })}
+                              {inv.lastPriceUpdate && (
+                                <div className="text-muted small" title={`Last refreshed ${new Date(inv.lastPriceUpdate).toLocaleString('en-AU')}`}>
+                                  <i className="fa fa-clock me-1" style={{ fontSize: '0.7rem' }}></i>
+                                  {formatRelative(inv.lastPriceUpdate)}
+                                </div>
+                              )}
+                            </td>
                             <td className={`text-end fw-bold ${gainLoss >= 0 ? 'text-success' : 'text-danger'}`}>
                               {gainLoss >= 0 ? '+' : ''}{gainLoss.toLocaleString('en-AU', { minimumFractionDigits: 2 })}
                               <small className="ms-1">({returnPct >= 0 ? '+' : ''}{returnPct.toFixed(1)}%)</small>
@@ -1107,6 +1234,16 @@ export default function InvestmentsPage() {
                               {cgt ? cgt.label : '—'}
                             </td>
                             <td className="text-nowrap">
+                              {inv.ticker && TRADED_TYPES.includes(inv.type) && (inv.units || 0) > 0 && (
+                                <button
+                                  className="btn btn-xs btn-outline-primary me-1"
+                                  onClick={() => refreshPrices(inv.id)}
+                                  disabled={refreshing}
+                                  title="Refresh price"
+                                >
+                                  <i className={`fa fa-arrows-rotate ${refreshing ? 'fa-spin' : ''}`}></i>
+                                </button>
+                              )}
                               <button className="btn btn-xs btn-primary me-1" onClick={() => startEdit(inv)} title="Edit">
                                 <i className="fa fa-pencil-alt"></i>
                               </button>

--- a/src/lib/functions-client.ts
+++ b/src/lib/functions-client.ts
@@ -209,3 +209,30 @@ export async function scanReceipt(imageBase64: string, mimeType: string): Promis
   const res = await fn({ imageBase64, mimeType });
   return res.data;
 }
+
+export interface PriceRefreshResult {
+  id: string;
+  ticker: string;
+  ok: boolean;
+  price?: number;
+  currency?: string;
+  fxToAud?: number;
+  currentValue?: number;
+  previousValue?: number;
+  updatedAt?: string;
+  error?: string;
+}
+
+export interface RefreshPricesResponse {
+  total: number;
+  updated: number;
+  failed: number;
+  results: PriceRefreshResult[];
+}
+
+export async function refreshInvestmentPrices(ids?: string[]): Promise<RefreshPricesResponse> {
+  if (guest.isGuest()) return guest.mockRefreshPrices(ids);
+  const fn = httpsCallable<{ ids?: string[] }, RefreshPricesResponse>(assertFunctions(), 'investmentsRefreshPrices');
+  const res = await fn(ids && ids.length > 0 ? { ids } : {});
+  return res.data;
+}

--- a/src/lib/guest-seed.ts
+++ b/src/lib/guest-seed.ts
@@ -46,9 +46,9 @@ const FAMILY: FamilyMember[] = [
 ];
 
 const INVESTMENTS: Investment[] = [
-  { id: 'inv-1', name: 'VAS', type: 'ETFs', owner: 'Sam', units: 450, buyPricePerUnit: 88.5, costBasis: 39825, currentValue: 45900 },
-  { id: 'inv-2', name: 'VGS', type: 'ETFs', owner: 'Sam', units: 220, buyPricePerUnit: 105.2, costBasis: 23144, currentValue: 28380 },
-  { id: 'inv-3', name: 'CBA', type: 'Australian Shares', owner: 'Alex', units: 120, buyPricePerUnit: 102.4, costBasis: 12288, currentValue: 15840 },
+  { id: 'inv-1', name: 'VAS', type: 'ETFs', owner: 'Sam', units: 450, buyPricePerUnit: 88.5, costBasis: 39825, currentValue: 45900, ticker: 'VAS.AX' },
+  { id: 'inv-2', name: 'VGS', type: 'ETFs', owner: 'Sam', units: 220, buyPricePerUnit: 105.2, costBasis: 23144, currentValue: 28380, ticker: 'VGS.AX' },
+  { id: 'inv-3', name: 'CBA', type: 'Australian Shares', owner: 'Alex', units: 120, buyPricePerUnit: 102.4, costBasis: 12288, currentValue: 15840, ticker: 'CBA.AX' },
   { id: 'inv-4', name: '42 Moreland St, Brunswick', type: 'Property', owner: 'Joint', propertyType: 'Investment', address: '42 Moreland St, Brunswick VIC 3056', costBasis: 720000, currentValue: 895000, liability: 512000, rentalIncomeMonthly: 2600 },
   { id: 'inv-5', name: 'AustralianSuper', type: 'Superannuation', owner: 'Sam', costBasis: 142000, currentValue: 142000, employerContribution: 12 },
   { id: 'inv-6', name: 'AustralianSuper', type: 'Superannuation', owner: 'Alex', costBasis: 86000, currentValue: 86000, employerContribution: 12 },

--- a/src/lib/guest-store.ts
+++ b/src/lib/guest-store.ts
@@ -104,6 +104,58 @@ export function deleteInvestment(id: string) {
   state.investments = state.investments.filter(i => i.id !== id);
 }
 
+const TRADED_TYPES = new Set(['Australian Shares', 'International Shares', 'ETFs', 'Cryptocurrency']);
+
+export function mockRefreshPrices(ids?: string[]): {
+  total: number;
+  updated: number;
+  failed: number;
+  results: {
+    id: string;
+    ticker: string;
+    ok: boolean;
+    price?: number;
+    currency?: string;
+    fxToAud?: number;
+    currentValue?: number;
+    previousValue?: number;
+    updatedAt?: string;
+    error?: string;
+  }[];
+} {
+  const eligible = state.investments.filter(inv => {
+    if (!inv.ticker || !TRADED_TYPES.has(inv.type) || !inv.units || inv.units <= 0) return false;
+    if (ids && ids.length > 0) return ids.includes(inv.id);
+    return true;
+  });
+  const nowIso = new Date().toISOString();
+  const results = eligible.map(inv => {
+    // Nudge price ±2.5% deterministically off current value to simulate a refresh.
+    const seed = (inv.id.charCodeAt(0) + inv.id.length + nowIso.length) % 50;
+    const drift = 1 + (seed - 25) / 1000;
+    const newValue = Number((inv.currentValue * drift).toFixed(2));
+    const newPrice = Number((newValue / (inv.units || 1)).toFixed(4));
+    const previousValue = inv.currentValue;
+    state.investments = state.investments.map(i =>
+      i.id === inv.id
+        ? { ...i, currentValue: newValue, lastPrice: newPrice, lastPriceCurrency: 'AUD', lastPriceUpdate: nowIso }
+        : i,
+    );
+    return {
+      id: inv.id,
+      ticker: inv.ticker!.toUpperCase(),
+      ok: true,
+      price: newPrice,
+      currency: 'AUD',
+      fxToAud: 1,
+      currentValue: newValue,
+      previousValue,
+      updatedAt: nowIso,
+    };
+  });
+  return { total: eligible.length, updated: results.length, failed: 0, results };
+}
+
 // Family members -----------------------------------------------------------
 
 export function listFamilyMembers(): FamilyMember[] {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,4 +83,10 @@ export interface Investment {
   couponRate?: number;
   maturityDate?: string;
   monthlyRepayment?: number;
+  // Live-price tracking (traded assets only). Yahoo Finance ticker, e.g.
+  // "BHP.AX", "AAPL", "BTC-AUD". `lastPrice` is per-unit in AUD after FX.
+  ticker?: string;
+  lastPrice?: number;
+  lastPriceCurrency?: string;
+  lastPriceUpdate?: string;
 }


### PR DESCRIPTION
Adds an `investmentsRefreshPrices` callable that pulls quotes from
Yahoo's `chart` endpoint for any traded holding with a `ticker` set
(Australian Shares, International Shares, ETFs, Cryptocurrency). Non-AUD
quotes are converted on the fly via the matching `<CCY>AUD=X` cross
rate, then `currentValue` (price × units) and a `lastPriceUpdate`
timestamp are written back per-investment.

On the Investments page:
- Traded-asset form gains an optional Ticker input with format hints
  (`.AX` for ASX, `BTC-AUD` for crypto).
- A "Refresh Prices" button appears in the Investments panel header
  whenever at least one holding has a ticker, and per-row refresh icons
  let users update one position at a time.
- Each refreshed row shows the source ticker under its name and a
  relative "as-of" timestamp next to Current Value.
- A status alert summarises updated/failed counts after each refresh.

Guest mode mocks a deterministic ±2.5% drift so the demo seed (VAS,
VGS, CBA pre-populated with `.AX` tickers) reacts to the new button.

Also marks Receipt Scanning (shipped in #60) and Live Share Prices done
in BACKLOG.md.