### PR TITLE
Notifications: real bell, /notifications page, prefs, EOFY emitter (#63)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,14 @@
         { "fieldPath": "financialYear", "order": "ASCENDING" },
         { "fieldPath": "date", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "notifications",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "readAt", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/src/handlers/notifications-cleanup.ts
+++ b/functions/src/handlers/notifications-cleanup.ts
@@ -1,0 +1,46 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { logger } from 'firebase-functions';
+import { getDb } from '../lib/firestore';
+
+const RETENTION_DAYS = 90;
+const BATCH_LIMIT = 400;
+
+/**
+ * Daily sweep that deletes read notifications older than 90 days. Iterates
+ * users via the `users` collection (one doc per email, matches the rest of
+ * the app).
+ */
+export const notificationsCleanup = onSchedule(
+  {
+    schedule: 'every day 02:00',
+    timeZone: 'Australia/Sydney',
+    region: 'australia-southeast1',
+    timeoutSeconds: 540,
+    memory: '256MiB',
+  },
+  async () => {
+    const db = getDb();
+    const cutoffIso = new Date(Date.now() - RETENTION_DAYS * 86_400_000).toISOString();
+
+    const users = await db.collection('users').listDocuments();
+    let totalDeleted = 0;
+
+    for (const userRef of users) {
+      // Firestore range comparators exclude null values, so this implicitly
+      // skips unread notifications.
+      const stale = await userRef
+        .collection('notifications')
+        .where('readAt', '<', cutoffIso)
+        .limit(BATCH_LIMIT)
+        .get();
+      if (stale.empty) continue;
+
+      const batch = db.batch();
+      stale.docs.forEach(d => batch.delete(d.ref));
+      await batch.commit();
+      totalDeleted += stale.size;
+    }
+
+    logger.info('notificationsCleanup deleted', { totalDeleted, cutoffIso });
+  },
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,3 +10,4 @@ export { expensesMigrate } from './handlers/expenses-migrate';
 export { expensesReanalyse } from './handlers/expenses-reanalyse';
 export { expensesCategoriseWorker } from './handlers/expenses-categorise-worker';
 export { cashflowImport } from './handlers/cashflow-import';
+export { notificationsCleanup } from './handlers/notifications-cleanup';

--- a/src/__tests__/notifications.test.tsx
+++ b/src/__tests__/notifications.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import {
+  isWithinQuietHours,
+  isInAppEnabled,
+  type NotificationPreferences,
+} from '@/lib/notification-types';
+import { currentFinancialYear, daysUntilEofy } from '@/lib/tax-deadline';
+
+const mockUnreadWatchers: Array<(c: number) => void> = [];
+const mockListWatchers: Array<(items: unknown[]) => void> = [];
+const mockMarkRead = jest.fn().mockResolvedValue(undefined);
+const mockMarkAllRead = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@/lib/firebase', () => ({ auth: null, db: null, app: null, functions: null }));
+
+jest.mock('@/lib/notifications-repo', () => ({
+  watchUnreadCount: (cb: (c: number) => void) => {
+    mockUnreadWatchers.push(cb);
+    cb(0);
+    return () => {
+      const i = mockUnreadWatchers.indexOf(cb);
+      if (i >= 0) mockUnreadWatchers.splice(i, 1);
+    };
+  },
+  watchRecentNotifications: (_max: number, cb: (items: unknown[]) => void) => {
+    mockListWatchers.push(cb);
+    cb([]);
+    return () => {
+      const i = mockListWatchers.indexOf(cb);
+      if (i >= 0) mockListWatchers.splice(i, 1);
+    };
+  },
+  markRead: (...args: unknown[]) => mockMarkRead(...args),
+  markAllRead: (...args: unknown[]) => mockMarkAllRead(...args),
+}));
+
+jest.mock('next/link', () => {
+  return function MockLink({ children, href }: { children: React.ReactNode; href: string }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import DropdownNotification from '@/components/header/dropdown/notification';
+
+beforeEach(() => {
+  mockUnreadWatchers.length = 0;
+  mockListWatchers.length = 0;
+  mockMarkRead.mockClear();
+  mockMarkAllRead.mockClear();
+  mockPush.mockClear();
+});
+
+describe('DropdownNotification', () => {
+  it('hides the badge when there are no unread notifications', () => {
+    render(<DropdownNotification />);
+    expect(screen.queryByText('9+')).not.toBeInTheDocument();
+    expect(screen.getByText('NOTIFICATIONS')).toBeInTheDocument();
+    expect(screen.getByText(/all caught up/i)).toBeInTheDocument();
+  });
+
+  it('caps the badge at 9+', async () => {
+    render(<DropdownNotification />);
+    await waitFor(() => expect(mockUnreadWatchers.length).toBeGreaterThan(0));
+    await act(async () => { mockUnreadWatchers[0](42); });
+    expect(screen.getByText('9+')).toBeInTheDocument();
+  });
+
+  it('renders notification items grouped and marks one read on click', async () => {
+    render(<DropdownNotification />);
+    await waitFor(() => expect(mockListWatchers.length).toBeGreaterThan(0));
+    const todayIso = new Date().toISOString();
+    const earlierIso = new Date(Date.now() - 4 * 86_400_000).toISOString();
+    await act(async () => {
+      mockListWatchers[0]([
+        { id: 'a', kind: 'system', title: 'Hello today', body: 'fresh', createdAt: todayIso, readAt: null },
+        { id: 'b', kind: 'recurring-due', title: 'From last week', body: 'old', createdAt: earlierIso, readAt: null, link: '/expenses' },
+      ]);
+    });
+    expect(screen.getByText('Hello today')).toBeInTheDocument();
+    expect(screen.getByText('Today')).toBeInTheDocument();
+    expect(screen.getByText('Earlier')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('From last week'));
+    await waitFor(() => expect(mockMarkRead).toHaveBeenCalledWith('b'));
+    expect(mockPush).toHaveBeenCalledWith('/expenses');
+  });
+
+  it('marks all read via the dropdown footer button', async () => {
+    render(<DropdownNotification />);
+    await waitFor(() => expect(mockUnreadWatchers.length).toBeGreaterThan(0));
+    await act(async () => { mockUnreadWatchers[0](3); });
+    const btn = await screen.findByRole('button', { name: /mark all read/i });
+    fireEvent.click(btn);
+    await waitFor(() => expect(mockMarkAllRead).toHaveBeenCalled());
+  });
+});
+
+describe('quiet hours', () => {
+  const prefsAt = (start: string, end: string): NotificationPreferences['quietHours'] => ({
+    enabled: true, startHHmm: start, endHHmm: end,
+  });
+
+  it('matches a wrap-around overnight window', () => {
+    const overnight = prefsAt('22:00', '07:00');
+    expect(isWithinQuietHours(overnight, new Date(2026, 0, 1, 23, 30))).toBe(true);
+    expect(isWithinQuietHours(overnight, new Date(2026, 0, 1, 6, 30))).toBe(true);
+    expect(isWithinQuietHours(overnight, new Date(2026, 0, 1, 8, 0))).toBe(false);
+  });
+
+  it('matches a same-day window', () => {
+    const lunch = prefsAt('12:00', '13:30');
+    expect(isWithinQuietHours(lunch, new Date(2026, 0, 1, 12, 30))).toBe(true);
+    expect(isWithinQuietHours(lunch, new Date(2026, 0, 1, 14, 0))).toBe(false);
+  });
+
+  it('returns false when disabled', () => {
+    expect(isWithinQuietHours({ enabled: false, startHHmm: '00:00', endHHmm: '23:59' })).toBe(false);
+  });
+});
+
+describe('channel helpers', () => {
+  it('treats undefined as in-app enabled (sensible default)', () => {
+    expect(isInAppEnabled(undefined)).toBe(true);
+    expect(isInAppEnabled('in-app')).toBe(true);
+    expect(isInAppEnabled('both')).toBe(true);
+    expect(isInAppEnabled('email')).toBe(false);
+    expect(isInAppEnabled('off')).toBe(false);
+  });
+});
+
+describe('tax deadline helpers', () => {
+  it('returns the FY containing the date (July onwards rolls over)', () => {
+    expect(currentFinancialYear(new Date(2026, 5, 30))).toBe('2025-2026'); // June
+    expect(currentFinancialYear(new Date(2026, 6, 1))).toBe('2026-2027'); // July
+  });
+
+  it('counts days down to 30 June', () => {
+    expect(daysUntilEofy(new Date(2026, 5, 29, 12, 0))).toBeGreaterThanOrEqual(1);
+    expect(daysUntilEofy(new Date(2026, 5, 30, 23, 0))).toBe(1);
+  });
+});

--- a/src/app/expenses/page.tsx
+++ b/src/app/expenses/page.tsx
@@ -9,6 +9,7 @@ import { listFamilyMembers } from '@/lib/family-members-repo';
 import { upsertCategoryRule } from '@/lib/category-rules-repo';
 import { getCategorySettings, setCategoryType, resolveType, type CategorySettings, type SpendingCategoryType } from '@/lib/category-settings-repo';
 import RecurringModal from '@/components/recurring-modal';
+import { notify } from '@/lib/notifications-repo';
 import BulkActionsBar from '@/components/bulk-actions-bar';
 import { MonthlyTrend, TopVendorsChart } from '@/components/spending-charts';
 import { ViewToggle, useViewMode } from '@/components/view-toggle';
@@ -1041,6 +1042,16 @@ export default function ExpensesPage() {
           onConfirm={async (items) => {
             const saved = await addExpenses(items);
             setExpenses(prev => [...prev, ...saved]);
+            const first = saved[0];
+            if (first) {
+              const last = saved[saved.length - 1];
+              notify({
+                kind: 'recurring-due',
+                title: `${saved.length} recurring expense${saved.length === 1 ? '' : 's'} created`,
+                body: `${first.description} · scheduled through ${new Date(last.date).toLocaleDateString('en-AU')}`,
+                link: '/expenses',
+              }).catch(() => {});
+            }
           }}
         />
       )}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Panel, PanelHeader, PanelBody } from '@/components/panel/panel';
+import {
+  watchRecentNotifications,
+  markRead,
+  markAllRead,
+} from '@/lib/notifications-repo';
+import { KIND_META, type Notification, type NotificationKind } from '@/lib/notification-types';
+
+const PAGE_LIMIT = 200;
+
+function formatStamp(iso: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleString('en-AU', {
+    day: '2-digit', month: 'short', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function dayKey(iso: string): string {
+  if (!iso) return 'Unknown';
+  return new Date(iso).toLocaleDateString('en-AU', {
+    weekday: 'long', day: '2-digit', month: 'short', year: 'numeric',
+  });
+}
+
+const FILTER_ALL = 'all' as const;
+type FilterKind = typeof FILTER_ALL | NotificationKind;
+
+export default function NotificationsPage() {
+  const router = useRouter();
+  const [items, setItems] = useState<Notification[]>([]);
+  const [filter, setFilter] = useState<FilterKind>(FILTER_ALL);
+  const [showRead, setShowRead] = useState(true);
+
+  useEffect(() => {
+    const off = watchRecentNotifications(PAGE_LIMIT, setItems);
+    return () => off();
+  }, []);
+
+  const filtered = items.filter(n => {
+    if (filter !== FILTER_ALL && n.kind !== filter) return false;
+    if (!showRead && n.readAt) return false;
+    return true;
+  });
+
+  const grouped = new Map<string, Notification[]>();
+  for (const n of filtered) {
+    const k = dayKey(n.createdAt);
+    if (!grouped.has(k)) grouped.set(k, []);
+    grouped.get(k)!.push(n);
+  }
+
+  const handleClick = async (n: Notification, e: React.MouseEvent) => {
+    if (!n.readAt) {
+      try { await markRead(n.id); } catch { /* swallow */ }
+    }
+    if (n.link) {
+      e.preventDefault();
+      router.push(n.link);
+    }
+  };
+
+  const unreadCount = items.filter(n => !n.readAt).length;
+  const kinds = Object.keys(KIND_META) as NotificationKind[];
+
+  return (
+    <>
+      <h1 className="page-header">Notifications</h1>
+
+      <Panel>
+        <PanelHeader noButton>
+          <span>All Notifications</span>
+        </PanelHeader>
+        <PanelBody>
+          <div className="d-flex flex-wrap gap-2 align-items-center mb-3">
+            <button
+              type="button"
+              className={`btn btn-sm ${filter === FILTER_ALL ? 'btn-primary' : 'btn-outline-secondary'}`}
+              onClick={() => setFilter(FILTER_ALL)}
+            >
+              All ({items.length})
+            </button>
+            {kinds.map(k => {
+              const count = items.filter(n => n.kind === k).length;
+              if (count === 0) return null;
+              const meta = KIND_META[k];
+              return (
+                <button
+                  key={k}
+                  type="button"
+                  className={`btn btn-sm ${filter === k ? 'btn-primary' : 'btn-outline-secondary'}`}
+                  onClick={() => setFilter(k)}
+                >
+                  <i className={`fa ${meta.icon} me-1`}></i>
+                  {meta.label} ({count})
+                </button>
+              );
+            })}
+            <div className="ms-auto d-flex gap-2">
+              <div className="form-check form-switch d-flex align-items-center gap-2 mb-0">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  id="show-read"
+                  checked={showRead}
+                  onChange={e => setShowRead(e.target.checked)}
+                />
+                <label className="form-check-label small mb-0" htmlFor="show-read">Show read</label>
+              </div>
+              {unreadCount > 0 && (
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-primary"
+                  onClick={() => markAllRead().catch(() => {})}
+                >
+                  Mark all read
+                </button>
+              )}
+              <Link href="/settings" className="btn btn-sm btn-outline-secondary">
+                <i className="fa fa-cog me-1"></i>Preferences
+              </Link>
+            </div>
+          </div>
+
+          {filtered.length === 0 ? (
+            <div className="text-center py-5 text-muted">
+              <i className="fa fa-check-circle fa-3x mb-3 d-block text-success"></i>
+              <p className="mb-0">You&apos;re all caught up.</p>
+            </div>
+          ) : (
+            [...grouped.entries()].map(([day, dayItems]) => (
+              <div key={day} className="mb-3">
+                <div className="text-uppercase small text-muted mb-2">{day}</div>
+                <div className="list-group">
+                  {dayItems.map(n => {
+                    const meta = KIND_META[n.kind];
+                    return (
+                      <a
+                        key={n.id}
+                        href={n.link || '#'}
+                        onClick={(e) => handleClick(n, e)}
+                        className={`list-group-item list-group-item-action d-flex align-items-start gap-3 ${n.readAt ? '' : 'bg-light'}`}
+                      >
+                        <span className={`fa-stack ${n.readAt ? 'text-muted' : 'text-primary'}`} style={{ fontSize: '0.6em' }}>
+                          <i className="fa fa-circle fa-stack-2x"></i>
+                          <i className={`fa ${meta?.icon || 'fa-bell'} fa-stack-1x text-white`}></i>
+                        </span>
+                        <span className="flex-grow-1">
+                          <div className={`d-flex justify-content-between align-items-baseline ${n.readAt ? '' : 'fw-bold'}`}>
+                            <span>{n.title}</span>
+                            <small className="text-muted ms-2">{formatStamp(n.createdAt)}</small>
+                          </div>
+                          <div className="small text-muted">{n.body}</div>
+                          {meta && <small className="text-muted">{meta.label}</small>}
+                        </span>
+                      </a>
+                    );
+                  })}
+                </div>
+              </div>
+            ))
+          )}
+        </PanelBody>
+      </Panel>
+    </>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { listExpenses } from '@/lib/expenses-repo';
 import { listInvestments } from '@/lib/investments-repo';
 import { listFamilyMembers } from '@/lib/family-members-repo';
 import { PageFilters, type FilterGroup } from '@/components/page-filters';
+import { maybeEmitEofyReminder } from '@/lib/tax-deadline';
 
 const CATEGORY_ICONS: Record<string, string> = {
   'Work from Home': 'fa-house-laptop',
@@ -70,6 +71,8 @@ export default function Dashboard() {
     fetchDashboardTips()
       .then(result => { setTips(result); setTipsLoading(false); })
       .catch(() => setTipsLoading(false));
+
+    maybeEmitEofyReminder().catch(() => {});
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import DataManagement from '@/components/data-management';
 import ExpensesExclusionSettings from '@/components/expenses-exclusion-settings';
 import CategoryReference from '@/components/category-reference';
 import CashflowReference from '@/components/cashflow-reference';
+import NotificationPreferencesPanel from '@/components/notification-preferences';
 
 export default function SettingsPage() {
   return (
@@ -17,6 +18,9 @@ export default function SettingsPage() {
 
       <h2 className="h4 mt-4 mb-3"><i className="fa fa-sack-dollar me-2"></i>Cashflow</h2>
       <CashflowReference />
+
+      <h2 className="h4 mt-4 mb-3"><i className="fa fa-bell me-2"></i>Notifications</h2>
+      <NotificationPreferencesPanel />
 
       <h2 className="h4 mt-4 mb-3"><i className="fa fa-database me-2"></i>Data Management</h2>
       <DataManagement />

--- a/src/components/header/dropdown/notification.tsx
+++ b/src/components/header/dropdown/notification.tsx
@@ -1,21 +1,149 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  watchUnreadCount,
+  watchRecentNotifications,
+  markRead,
+  markAllRead,
+} from '@/lib/notifications-repo';
+import { KIND_META, type Notification } from '@/lib/notification-types';
+
+const RECENT_LIMIT = 10;
+
+function relativeTime(iso: string): string {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return '';
+  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (diffSec < 60) return 'just now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(iso).toLocaleDateString('en-AU');
+}
+
+function isToday(iso: string): boolean {
+  if (!iso) return false;
+  return new Date(iso).toLocaleDateString('en-AU') === new Date().toLocaleDateString('en-AU');
+}
 
 export default function DropdownNotification() {
+  const router = useRouter();
+  const [unread, setUnread] = useState(0);
+  const [recent, setRecent] = useState<Notification[]>([]);
+
+  useEffect(() => {
+    const offCount = watchUnreadCount(setUnread);
+    const offList = watchRecentNotifications(RECENT_LIMIT, setRecent);
+    return () => { offCount(); offList(); };
+  }, []);
+
+  const handleClick = async (n: Notification, e: React.MouseEvent) => {
+    if (!n.readAt) {
+      try { await markRead(n.id); } catch { /* swallow */ }
+    }
+    if (n.link) {
+      e.preventDefault();
+      router.push(n.link);
+    }
+  };
+
+  const handleMarkAll = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try { await markAllRead(); } catch { /* swallow */ }
+  };
+
+  const todayItems = recent.filter(n => isToday(n.createdAt));
+  const earlierItems = recent.filter(n => !isToday(n.createdAt));
+  const badgeText = unread === 0 ? null : unread > 9 ? '9+' : String(unread);
+
   return (
     <div className="navbar-item dropdown">
-      <a href="#" data-bs-toggle="dropdown" className="navbar-link dropdown-toggle icon">
+      <a
+        href="#"
+        data-bs-toggle="dropdown"
+        className="navbar-link dropdown-toggle icon"
+        aria-label={unread > 0 ? `${unread} unread notifications` : 'Notifications'}
+      >
         <i className="fa fa-bell"></i>
-        <span className="badge">0</span>
+        {badgeText && <span className="badge">{badgeText}</span>}
       </a>
-      <div className="dropdown-menu media-list dropdown-menu-end">
-        <div className="dropdown-header">NOTIFICATIONS (5)</div>
-        
-        <div className="text-center w-300px py-3">
-					No notification found
-				</div>
+      <div className="dropdown-menu media-list dropdown-menu-end" style={{ minWidth: 320 }}>
+        <div className="dropdown-header d-flex justify-content-between align-items-center">
+          <span>NOTIFICATIONS{unread > 0 ? ` (${unread})` : ''}</span>
+          {unread > 0 && (
+            <button
+              type="button"
+              className="btn btn-link btn-sm p-0 text-decoration-none"
+              onClick={handleMarkAll}
+            >
+              Mark all read
+            </button>
+          )}
+        </div>
+
+        {recent.length === 0 && (
+          <div className="text-center py-4 px-3 text-muted">
+            <i className="fa fa-check-circle fa-2x mb-2 d-block text-success"></i>
+            You&apos;re all caught up
+          </div>
+        )}
+
+        {todayItems.length > 0 && (
+          <>
+            <div className="dropdown-header text-uppercase small text-muted">Today</div>
+            {todayItems.map(n => (
+              <NotificationItem key={n.id} n={n} onClick={handleClick} />
+            ))}
+          </>
+        )}
+
+        {earlierItems.length > 0 && (
+          <>
+            <div className="dropdown-header text-uppercase small text-muted">Earlier</div>
+            {earlierItems.map(n => (
+              <NotificationItem key={n.id} n={n} onClick={handleClick} />
+            ))}
+          </>
+        )}
+
+        <div className="dropdown-footer text-center">
+          <Link href="/notifications" className="text-decoration-none">View all</Link>
+        </div>
       </div>
     </div>
+  );
+}
+
+interface ItemProps {
+  n: Notification;
+  onClick: (n: Notification, e: React.MouseEvent) => void;
+}
+
+function NotificationItem({ n, onClick }: ItemProps) {
+  const meta = KIND_META[n.kind];
+  const icon = meta?.icon || 'fa-bell';
+  return (
+    <a
+      href={n.link || '#'}
+      className={`dropdown-item d-flex align-items-start gap-2 py-2 ${n.readAt ? '' : 'fw-bold'}`}
+      onClick={(e) => onClick(n, e)}
+    >
+      <span className={`media-icon ${n.readAt ? 'text-muted' : 'text-primary'}`} style={{ flex: '0 0 auto' }}>
+        <i className={`fa ${icon}`}></i>
+      </span>
+      <span className="flex-grow-1" style={{ whiteSpace: 'normal' }}>
+        <span className="d-block">{n.title}</span>
+        <small className="d-block text-muted">{n.body}</small>
+        <small className="d-block text-muted">{relativeTime(n.createdAt)}</small>
+      </span>
+    </a>
   );
 }

--- a/src/components/notification-preferences.tsx
+++ b/src/components/notification-preferences.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Panel, PanelHeader, PanelBody } from '@/components/panel/panel';
+import {
+  getNotificationPreferences,
+  saveNotificationPreferences,
+} from '@/lib/notification-preferences-repo';
+import {
+  CHANNEL_OPTIONS,
+  DEFAULT_PREFERENCES,
+  KIND_META,
+  type NotificationChannel,
+  type NotificationKind,
+  type NotificationPreferences,
+} from '@/lib/notification-types';
+
+const KINDS = Object.keys(KIND_META) as NotificationKind[];
+
+export default function NotificationPreferencesPanel() {
+  const [prefs, setPrefs] = useState<NotificationPreferences>(DEFAULT_PREFERENCES);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    getNotificationPreferences()
+      .then(setPrefs)
+      .catch(() => setPrefs({ ...DEFAULT_PREFERENCES }))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const persist = async (next: NotificationPreferences) => {
+    setPrefs(next);
+    setSaving(true);
+    try {
+      await saveNotificationPreferences(next);
+      setSavedAt(Date.now());
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const updateChannel = (kind: NotificationKind, channel: NotificationChannel) => {
+    persist({ ...prefs, perKind: { ...prefs.perKind, [kind]: channel } });
+  };
+
+  const updateQuietHours = (patch: Partial<NotificationPreferences['quietHours']>) => {
+    persist({ ...prefs, quietHours: { ...prefs.quietHours, ...patch } });
+  };
+
+  return (
+    <Panel className="mt-4">
+      <PanelHeader noButton>
+        <i className="fa fa-bell me-2"></i>Notifications
+      </PanelHeader>
+      <PanelBody>
+        {loading ? (
+          <div className="text-muted small"><i className="fa fa-spinner fa-spin me-1"></i>Loading…</div>
+        ) : (
+          <>
+            <p className="text-muted small mb-3">
+              Choose how each kind of alert reaches you. Email delivery is wired up as features
+              (budgets, EOFY checklist) ship — for now everything routes through the in-app bell.
+            </p>
+
+            <div className="table-responsive mb-4">
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th style={{ width: '45%' }}>Notification</th>
+                    <th>Delivery</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {KINDS.map(kind => {
+                    const meta = KIND_META[kind];
+                    const channel = prefs.perKind[kind] ?? 'in-app';
+                    return (
+                      <tr key={kind}>
+                        <td>
+                          <div className="d-flex align-items-start gap-2">
+                            <i className={`fa ${meta.icon} text-muted mt-1`}></i>
+                            <div>
+                              <div>{meta.label}</div>
+                              <small className="text-muted">{meta.description}</small>
+                            </div>
+                          </div>
+                        </td>
+                        <td>
+                          <select
+                            className="form-select form-select-sm"
+                            value={channel}
+                            onChange={(e) => updateChannel(kind, e.target.value as NotificationChannel)}
+                            disabled={saving}
+                          >
+                            {CHANNEL_OPTIONS.map(opt => (
+                              <option key={opt.value} value={opt.value}>{opt.label}</option>
+                            ))}
+                          </select>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            <h6 className="mb-2">Quiet hours</h6>
+            <p className="text-muted small mb-3">
+              Push notifications are suppressed during this window. In-app entries still appear so
+              you can catch up the next morning.
+            </p>
+            <div className="row g-2 align-items-center">
+              <div className="col-auto">
+                <div className="form-check form-switch">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    id="quiet-hours-enabled"
+                    checked={prefs.quietHours.enabled}
+                    onChange={e => updateQuietHours({ enabled: e.target.checked })}
+                    disabled={saving}
+                  />
+                  <label className="form-check-label" htmlFor="quiet-hours-enabled">Enabled</label>
+                </div>
+              </div>
+              <div className="col-auto">
+                <label className="form-label small mb-0 me-1">From</label>
+                <input
+                  type="time"
+                  className="form-control form-control-sm d-inline-block"
+                  style={{ width: 110 }}
+                  value={prefs.quietHours.startHHmm}
+                  onChange={e => updateQuietHours({ startHHmm: e.target.value || '22:00' })}
+                  disabled={saving || !prefs.quietHours.enabled}
+                />
+              </div>
+              <div className="col-auto">
+                <label className="form-label small mb-0 me-1">To</label>
+                <input
+                  type="time"
+                  className="form-control form-control-sm d-inline-block"
+                  style={{ width: 110 }}
+                  value={prefs.quietHours.endHHmm}
+                  onChange={e => updateQuietHours({ endHHmm: e.target.value || '07:00' })}
+                  disabled={saving || !prefs.quietHours.enabled}
+                />
+              </div>
+              <div className="col-auto ms-auto">
+                {saving && <small className="text-muted"><i className="fa fa-spinner fa-spin me-1"></i>Saving</small>}
+                {!saving && savedAt && <small className="text-success"><i className="fa fa-check me-1"></i>Saved</small>}
+              </div>
+            </div>
+          </>
+        )}
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/src/lib/guest-store.ts
+++ b/src/lib/guest-store.ts
@@ -1,5 +1,6 @@
 import { GUEST_SEED } from './guest-seed';
 import type { Expense, FamilyMember, Investment, IncomeSource } from './types';
+import type { Notification, NotificationKind, NotificationPreferences } from './notification-types';
 
 const FLAG_KEY = 'fd_guest';
 
@@ -46,6 +47,8 @@ interface GuestState {
   adviceChats: Record<string, ChatMessage[] | string[]>;
   categorySettings?: CategorySettings;
   incomeSources?: IncomeSource[];
+  notifications?: Notification[];
+  notificationPreferences?: NotificationPreferences;
 }
 
 function clone<T>(v: T): T {
@@ -240,4 +243,57 @@ export function updateIncomeSource(id: string, patch: Partial<IncomeSource>) {
 
 export function deleteIncomeSource(id: string) {
   state.incomeSources = (state.incomeSources || []).filter(i => i.id !== id);
+}
+
+// Notifications -----------------------------------------------------------
+
+export function listNotifications(): Notification[] {
+  return [...(state.notifications || [])].sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''));
+}
+
+interface AddNotificationInput {
+  kind: NotificationKind;
+  title: string;
+  body: string;
+  link?: string;
+  dedupeId?: string;
+}
+
+export function addNotification(input: AddNotificationInput): Notification {
+  const list = state.notifications || [];
+  if (input.dedupeId) {
+    const existing = list.find(n => n.id === input.dedupeId);
+    if (existing) return existing;
+  }
+  const notif: Notification = {
+    id: input.dedupeId || rid('n'),
+    kind: input.kind,
+    title: input.title,
+    body: input.body,
+    link: input.link,
+    createdAt: new Date().toISOString(),
+    readAt: null,
+  };
+  state.notifications = [notif, ...list];
+  return notif;
+}
+
+export function markNotificationRead(id: string) {
+  const now = new Date().toISOString();
+  state.notifications = (state.notifications || []).map(n =>
+    n.id === id ? { ...n, readAt: n.readAt || now } : n,
+  );
+}
+
+export function markAllNotificationsRead() {
+  const now = new Date().toISOString();
+  state.notifications = (state.notifications || []).map(n => ({ ...n, readAt: n.readAt || now }));
+}
+
+export function getNotificationPreferences(): NotificationPreferences | undefined {
+  return state.notificationPreferences;
+}
+
+export function setNotificationPreferences(prefs: NotificationPreferences) {
+  state.notificationPreferences = prefs;
 }

--- a/src/lib/notification-preferences-repo.ts
+++ b/src/lib/notification-preferences-repo.ts
@@ -1,0 +1,40 @@
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { auth, db } from './firebase';
+import * as guest from './guest-store';
+import {
+  DEFAULT_PREFERENCES,
+  type NotificationPreferences,
+} from './notification-types';
+
+function getUserKey(): string {
+  const email = auth?.currentUser?.email;
+  if (!email) throw new Error('Not authenticated');
+  return email;
+}
+
+function prefsRef() {
+  if (!db) throw new Error('Firestore is not initialised');
+  return doc(db, 'users', getUserKey(), 'meta', 'notification-preferences');
+}
+
+function withDefaults(partial: Partial<NotificationPreferences> | undefined): NotificationPreferences {
+  return {
+    perKind: { ...DEFAULT_PREFERENCES.perKind, ...(partial?.perKind || {}) },
+    quietHours: { ...DEFAULT_PREFERENCES.quietHours, ...(partial?.quietHours || {}) },
+  };
+}
+
+export async function getNotificationPreferences(): Promise<NotificationPreferences> {
+  if (guest.isGuest()) return withDefaults(guest.getNotificationPreferences());
+  try {
+    const snap = await getDoc(prefsRef());
+    return withDefaults(snap.exists() ? (snap.data() as Partial<NotificationPreferences>) : {});
+  } catch {
+    return { ...DEFAULT_PREFERENCES };
+  }
+}
+
+export async function saveNotificationPreferences(prefs: NotificationPreferences): Promise<void> {
+  if (guest.isGuest()) { guest.setNotificationPreferences(prefs); return; }
+  await setDoc(prefsRef(), prefs);
+}

--- a/src/lib/notification-types.ts
+++ b/src/lib/notification-types.ts
@@ -1,0 +1,102 @@
+export type NotificationKind =
+  | 'tax-deadline'
+  | 'budget-alert'
+  | 'recurring-due'
+  | 'price-alert'
+  | 'goal-milestone'
+  | 'system';
+
+export interface Notification {
+  id: string;
+  kind: NotificationKind;
+  title: string;
+  body: string;
+  link?: string;
+  createdAt: string; // ISO 8601
+  readAt: string | null;
+}
+
+export type NotificationChannel = 'in-app' | 'email' | 'both' | 'off';
+
+export interface QuietHours {
+  enabled: boolean;
+  startHHmm: string; // 'HH:mm' 24h
+  endHHmm: string;
+}
+
+export interface NotificationPreferences {
+  perKind: Partial<Record<NotificationKind, NotificationChannel>>;
+  quietHours: QuietHours;
+}
+
+export const DEFAULT_PREFERENCES: NotificationPreferences = {
+  perKind: {
+    'tax-deadline': 'in-app',
+    'budget-alert': 'in-app',
+    'recurring-due': 'in-app',
+    'price-alert': 'in-app',
+    'goal-milestone': 'in-app',
+    'system': 'in-app',
+  },
+  quietHours: { enabled: false, startHHmm: '22:00', endHHmm: '07:00' },
+};
+
+export const KIND_META: Record<NotificationKind, { label: string; icon: string; description: string }> = {
+  'tax-deadline': {
+    label: 'Tax deadlines',
+    icon: 'fa-calendar-day',
+    description: 'EOFY countdown and ATO lodgement reminders.',
+  },
+  'budget-alert': {
+    label: 'Budget alerts',
+    icon: 'fa-gauge-high',
+    description: 'When a category is approaching or has exceeded its limit.',
+  },
+  'recurring-due': {
+    label: 'Recurring expenses',
+    icon: 'fa-repeat',
+    description: 'When recurring expense occurrences are generated.',
+  },
+  'price-alert': {
+    label: 'Price alerts',
+    icon: 'fa-chart-line',
+    description: 'Significant moves on your tracked holdings.',
+  },
+  'goal-milestone': {
+    label: 'Savings goals',
+    icon: 'fa-bullseye',
+    description: 'When a goal hits a milestone or completes.',
+  },
+  'system': {
+    label: 'System',
+    icon: 'fa-bell',
+    description: 'App updates, tips, and admin messages.',
+  },
+};
+
+export const CHANNEL_OPTIONS: { value: NotificationChannel; label: string }[] = [
+  { value: 'in-app', label: 'In-app only' },
+  { value: 'email', label: 'Email only' },
+  { value: 'both', label: 'In-app and email' },
+  { value: 'off', label: 'Off' },
+];
+
+export function isInAppEnabled(channel: NotificationChannel | undefined): boolean {
+  if (!channel) return true;
+  return channel === 'in-app' || channel === 'both';
+}
+
+/** True if `now` falls within the [startHHmm, endHHmm) window — wrap supported. */
+export function isWithinQuietHours(prefs: QuietHours, now: Date = new Date()): boolean {
+  if (!prefs.enabled) return false;
+  const cur = now.getHours() * 60 + now.getMinutes();
+  const start = parseHHmm(prefs.startHHmm);
+  const end = parseHHmm(prefs.endHHmm);
+  if (start === end) return false;
+  return start < end ? cur >= start && cur < end : cur >= start || cur < end;
+}
+
+function parseHHmm(s: string): number {
+  const [h, m] = s.split(':').map(n => parseInt(n, 10) || 0);
+  return h * 60 + m;
+}

--- a/src/lib/notifications-repo.ts
+++ b/src/lib/notifications-repo.ts
@@ -1,0 +1,159 @@
+import {
+  collection,
+  query,
+  where,
+  orderBy,
+  limit,
+  getDocs,
+  doc,
+  setDoc,
+  updateDoc,
+  writeBatch,
+  onSnapshot,
+  type CollectionReference,
+} from 'firebase/firestore';
+import { auth, db } from './firebase';
+import * as guest from './guest-store';
+import {
+  DEFAULT_PREFERENCES,
+  isInAppEnabled,
+  type Notification,
+  type NotificationKind,
+  type NotificationPreferences,
+} from './notification-types';
+import { getNotificationPreferences } from './notification-preferences-repo';
+
+function getUserKey(): string {
+  const email = auth?.currentUser?.email;
+  if (!email) throw new Error('Not authenticated');
+  return email;
+}
+
+function notificationsCollection(): CollectionReference {
+  if (!db) throw new Error('Firestore is not initialised');
+  return collection(db, 'users', getUserKey(), 'notifications');
+}
+
+interface NotifyInput {
+  kind: NotificationKind;
+  title: string;
+  body: string;
+  link?: string;
+  /** Deterministic id for de-duplication (e.g. `tax-deadline-2025-2026-30`). */
+  dedupeId?: string;
+}
+
+/**
+ * Write a notification, honouring the user's per-kind preferences. No-op when
+ * the kind is disabled or when running in guest/non-auth mode that can't reach
+ * Firestore. Returns true if the notification was written (or already exists).
+ */
+export async function notify(input: NotifyInput): Promise<boolean> {
+  let prefs: NotificationPreferences;
+  try {
+    prefs = await getNotificationPreferences();
+  } catch {
+    prefs = { ...DEFAULT_PREFERENCES };
+  }
+  const channel = prefs.perKind[input.kind];
+  if (channel === 'off') return false;
+  if (!isInAppEnabled(channel)) return false;
+
+  if (guest.isGuest()) {
+    guest.addNotification({
+      kind: input.kind,
+      title: input.title,
+      body: input.body,
+      link: input.link,
+      dedupeId: input.dedupeId,
+    });
+    return true;
+  }
+
+  if (!auth?.currentUser?.email || !db) return false;
+
+  const col = notificationsCollection();
+  const ref = input.dedupeId ? doc(col, input.dedupeId) : doc(col);
+  const payload: Notification = {
+    id: ref.id,
+    kind: input.kind,
+    title: input.title,
+    body: input.body,
+    link: input.link,
+    createdAt: new Date().toISOString(),
+    readAt: null,
+  };
+  try {
+    // setDoc with deterministic id is idempotent — repeated emits reuse the
+    // same doc instead of producing duplicates.
+    await setDoc(ref, payload, { merge: !!input.dedupeId });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function listNotifications(max: number = 50): Promise<Notification[]> {
+  if (guest.isGuest()) return guest.listNotifications().slice(0, max);
+  try {
+    const col = notificationsCollection();
+    const q = query(col, orderBy('createdAt', 'desc'), limit(max));
+    const snap = await getDocs(q);
+    return snap.docs.map(d => ({ id: d.id, ...d.data() } as Notification));
+  } catch {
+    return [];
+  }
+}
+
+export function watchUnreadCount(onChange: (count: number) => void): () => void {
+  if (guest.isGuest()) {
+    onChange(guest.listNotifications().filter(n => !n.readAt).length);
+    return () => {};
+  }
+  try {
+    const col = notificationsCollection();
+    const q = query(col, where('readAt', '==', null));
+    return onSnapshot(q, snap => onChange(snap.size), () => onChange(0));
+  } catch {
+    return () => {};
+  }
+}
+
+export function watchRecentNotifications(
+  max: number,
+  onChange: (notifications: Notification[]) => void,
+): () => void {
+  if (guest.isGuest()) {
+    onChange(guest.listNotifications().slice(0, max));
+    return () => {};
+  }
+  try {
+    const col = notificationsCollection();
+    const q = query(col, orderBy('createdAt', 'desc'), limit(max));
+    return onSnapshot(q, snap => {
+      onChange(snap.docs.map(d => ({ id: d.id, ...d.data() } as Notification)));
+    }, () => onChange([]));
+  } catch {
+    return () => {};
+  }
+}
+
+export async function markRead(id: string): Promise<void> {
+  if (guest.isGuest()) { guest.markNotificationRead(id); return; }
+  if (!db) return;
+  const ref = doc(db, 'users', getUserKey(), 'notifications', id);
+  await updateDoc(ref, { readAt: new Date().toISOString() });
+}
+
+export async function markAllRead(): Promise<void> {
+  if (guest.isGuest()) { guest.markAllNotificationsRead(); return; }
+  if (!db) return;
+  const col = notificationsCollection();
+  const q = query(col, where('readAt', '==', null));
+  const snap = await getDocs(q);
+  if (snap.empty) return;
+  const batch = writeBatch(db);
+  const now = new Date().toISOString();
+  snap.docs.forEach(d => batch.update(d.ref, { readAt: now }));
+  await batch.commit();
+}

--- a/src/lib/tax-deadline.ts
+++ b/src/lib/tax-deadline.ts
@@ -1,0 +1,50 @@
+import { notify } from './notifications-repo';
+
+/**
+ * Australian financial year ends 30 June. Returns the FY string (e.g. `2025-2026`)
+ * the supplied date falls inside.
+ */
+export function currentFinancialYear(now: Date = new Date()): string {
+  const y = now.getFullYear();
+  const m = now.getMonth() + 1;
+  return m >= 7 ? `${y}-${y + 1}` : `${y - 1}-${y}`;
+}
+
+/** Number of whole calendar days between `now` and the next 30 June (>= 0). */
+export function daysUntilEofy(now: Date = new Date()): number {
+  const fy = currentFinancialYear(now);
+  const endYear = Number(fy.split('-')[1]);
+  const eofy = new Date(endYear, 5, 30, 23, 59, 59); // June = 5
+  const ms = eofy.getTime() - now.getTime();
+  return Math.max(0, Math.ceil(ms / 86_400_000));
+}
+
+const TRIGGER_DAYS = [60, 30, 14, 7, 1, 0] as const;
+
+/**
+ * Emit a once-per-FY-per-trigger reminder when the EOFY is within a milestone
+ * window. Idempotent — `dedupeId` keys the doc deterministically so refreshing
+ * the page doesn't pile up duplicates.
+ */
+export async function maybeEmitEofyReminder(now: Date = new Date()): Promise<void> {
+  const days = daysUntilEofy(now);
+  // Pick the smallest trigger we've crossed. (e.g. 5 days out → emit the "7-day" reminder
+  // since the 1-day one hasn't fired yet.)
+  const trigger = TRIGGER_DAYS.find(t => days <= t);
+  if (trigger === undefined) return;
+  const fy = currentFinancialYear(now);
+  const dedupeId = `tax-deadline-${fy}-${trigger}`;
+  const title = trigger === 0
+    ? 'Today is EOFY'
+    : `${trigger} day${trigger === 1 ? '' : 's'} until EOFY`;
+  const body = trigger === 0
+    ? `End of financial year ${fy} — finalise deductions and stocktake before midnight.`
+    : `EOFY (30 June) for FY ${fy} is ${trigger} day${trigger === 1 ? '' : 's'} away. Review your deductions on the Tax page.`;
+  await notify({
+    kind: 'tax-deadline',
+    title,
+    body,
+    link: '/tax',
+    dedupeId,
+  });
+}


### PR DESCRIPTION
Replaces the static "0 notifications" stub with a working in-app
notification center backed by users/{email}/notifications:

- Bell shows live unread count (capped at 9+) and the most recent 10,
  grouped Today / Earlier; clicking marks the item read and routes to
  its link.
- /notifications full-history page with kind filter chips, show-read
  toggle and Mark all read.
- Settings → Notifications panel: per-kind delivery channel
  (in-app / email / both / off) plus a quiet-hours window for future
  push.
- notify() dispatcher honours per-kind prefs and supports a deterministic
  dedupeId so deadline reminders don't pile up across reloads.
- Recurring expenses fire a recurring-due notification after creation;
  the dashboard fires a tax-deadline reminder at 60/30/14/7/1/0 days out
  from EOFY (FY-keyed dedupe).
- Daily scheduled Cloud Function purges read notifications older than
  90 days. Composite index added on (readAt, createdAt desc).
- Guest-mode mirror so the system works without Firestore.

https://claude.ai/code/session_01Py1rULeKWr8z8RR5ZU6aiY