### PR TITLE
Preferences: display/defaults/privacy + AI kill switch (#75)

### DIFF
--- a/functions/src/handlers/budgets-alerts.ts
+++ b/functions/src/handlers/budgets-alerts.ts
@@ -1,0 +1,163 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { logger } from 'firebase-functions';
+import { getDb } from '../lib/firestore';
+
+interface Budget {
+  id: string;
+  scope: 'overall' | 'spending-category' | 'spending-sub-category';
+  category?: string;
+  subCategory?: string;
+  amount: number;
+  startMonth: string;
+  rolloverUnused: boolean;
+  alertThresholds: number[];
+  lastAlertedMonth?: string;
+  lastAlertedThreshold?: number;
+}
+
+interface ExpenseDoc {
+  date?: string;
+  amount?: number;
+  spendingCategory?: string;
+  spendingSubCategory?: string;
+}
+
+interface NotificationPreferences {
+  perKind?: Record<string, 'in-app' | 'email' | 'both' | 'off'>;
+}
+
+const DEFAULT_THRESHOLDS = [0.8, 1.0, 1.2];
+
+function monthKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function previousMonth(ym: string): string {
+  const [y, m] = ym.split('-').map(Number);
+  if (m === 1) return `${y - 1}-12`;
+  return `${y}-${String(m - 1).padStart(2, '0')}`;
+}
+
+function matches(budget: Budget, e: ExpenseDoc): boolean {
+  if (budget.scope === 'overall') return true;
+  if (budget.scope === 'spending-category') return e.spendingCategory === budget.category;
+  return e.spendingCategory === budget.category && e.spendingSubCategory === budget.subCategory;
+}
+
+function spendForMonth(budget: Budget, expenses: ExpenseDoc[], month: string): number {
+  let total = 0;
+  for (const e of expenses) {
+    if (!e?.date || typeof e.amount !== 'number') continue;
+    if (e.date.slice(0, 7) !== month) continue;
+    if (!matches(budget, e)) continue;
+    total += e.amount;
+  }
+  return total;
+}
+
+function rolloverInForMonth(budget: Budget, expenses: ExpenseDoc[], month: string): number {
+  if (!budget.rolloverUnused) return 0;
+  if (month <= budget.startMonth) return 0;
+  const prev = previousMonth(month);
+  const prevSpend = spendForMonth(budget, expenses, prev);
+  const surplus = budget.amount - prevSpend;
+  if (surplus <= 0) return 0;
+  return Math.min(surplus, budget.amount);
+}
+
+function nextThresholdToAlert(budget: Budget, ratio: number, month: string): number | null {
+  const thresholds = budget.alertThresholds?.length
+    ? [...budget.alertThresholds].sort((a, b) => a - b)
+    : [...DEFAULT_THRESHOLDS];
+  const sameMonth = budget.lastAlertedMonth === month;
+  const ceiling = sameMonth ? (budget.lastAlertedThreshold ?? -Infinity) : -Infinity;
+  let next: number | null = null;
+  for (const t of thresholds) {
+    if (ratio >= t && t > ceiling) next = t;
+  }
+  return next;
+}
+
+function describeBudget(b: Budget): string {
+  if (b.scope === 'overall') return 'Overall monthly spending';
+  if (b.scope === 'spending-sub-category') return `${b.category} → ${b.subCategory}`;
+  return b.category ?? 'Uncategorised';
+}
+
+/**
+ * Hourly cron: for each user, computes month-to-date spend per budget and
+ * writes a `budget-alert` notification when a new threshold is crossed. The
+ * budget doc carries `lastAlertedMonth` + `lastAlertedThreshold` so each
+ * threshold fires at most once per month per budget.
+ */
+export const budgetsAlerts = onSchedule(
+  {
+    schedule: 'every 1 hours',
+    timeZone: 'Australia/Sydney',
+    region: 'australia-southeast1',
+    timeoutSeconds: 540,
+    memory: '256MiB',
+  },
+  async () => {
+    const db = getDb();
+    const month = monthKey(new Date());
+    let alertsWritten = 0;
+
+    const users = await db.collection('users').listDocuments();
+    for (const userRef of users) {
+      const budgetsSnap = await userRef.collection('budgets').get();
+      if (budgetsSnap.empty) continue;
+
+      const expensesSnap = await userRef
+        .collection('expenses')
+        .where('date', '>=', `${previousMonth(month)}-01`)
+        .get();
+      const expenses = expensesSnap.docs.map(d => d.data() as ExpenseDoc);
+
+      // Pull notification preferences once per user; default to in-app on.
+      const prefsSnap = await userRef.collection('meta').doc('notification-preferences').get();
+      const prefs = (prefsSnap.exists ? prefsSnap.data() : {}) as NotificationPreferences;
+      const channel = prefs.perKind?.['budget-alert'] ?? 'in-app';
+      if (channel === 'off') continue;
+      const inApp = channel === 'in-app' || channel === 'both';
+      if (!inApp) continue;
+
+      for (const budgetDoc of budgetsSnap.docs) {
+        const budget = { id: budgetDoc.id, ...(budgetDoc.data() as Omit<Budget, 'id'>) };
+        const spent = spendForMonth(budget, expenses, month);
+        const rolloverIn = rolloverInForMonth(budget, expenses, month);
+        const effectiveCap = Math.max(0.01, budget.amount + rolloverIn);
+        const ratio = spent / effectiveCap;
+        const threshold = nextThresholdToAlert(budget, ratio, month);
+        if (threshold === null) continue;
+
+        const dedupeId = `budget-${budget.id}-${month}-${Math.round(threshold * 100)}`;
+        const notifRef = userRef.collection('notifications').doc(dedupeId);
+        const pct = Math.round(threshold * 100);
+        const title = pct >= 100
+          ? `${describeBudget(budget)} budget exceeded (${pct}%)`
+          : `${describeBudget(budget)} budget at ${pct}%`;
+        const body = `Spent $${spent.toFixed(2)} of $${effectiveCap.toFixed(2)} for ${month}.`;
+
+        const batch = db.batch();
+        batch.set(notifRef, {
+          id: dedupeId,
+          kind: 'budget-alert',
+          title,
+          body,
+          link: '/budgets',
+          createdAt: new Date().toISOString(),
+          readAt: null,
+        }, { merge: true });
+        batch.update(budgetDoc.ref, {
+          lastAlertedMonth: month,
+          lastAlertedThreshold: threshold,
+        });
+        await batch.commit();
+        alertsWritten += 1;
+      }
+    }
+
+    logger.info('budgetsAlerts swept', { alertsWritten, month });
+  },
+);

--- a/functions/src/handlers/networth-snapshot.ts
+++ b/functions/src/handlers/networth-snapshot.ts
@@ -1,0 +1,96 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { logger } from 'firebase-functions';
+import { getDb } from '../lib/firestore';
+
+interface InvestmentDoc {
+  type?: string;
+  owner?: string;
+  currentValue?: number;
+}
+
+interface LiabilityDoc {
+  kind?: string;
+  owner?: string;
+  currentBalance?: number;
+}
+
+const JOINT_KEY = '__joint';
+
+function monthKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+/**
+ * Monthly cron: snapshots each user's current net-worth roll-up to
+ * users/{email}/networth-history/{YYYY-MM}. Runs at 03:00 on the 1st.
+ *
+ * The on-page "Save snapshot" button writes the same shape on demand —
+ * this cron is the safety net for users who don't open the app each month.
+ */
+export const networthSnapshot = onSchedule(
+  {
+    schedule: '0 3 1 * *',
+    timeZone: 'Australia/Sydney',
+    region: 'australia-southeast1',
+    timeoutSeconds: 540,
+    memory: '256MiB',
+  },
+  async () => {
+    const db = getDb();
+    const month = monthKey(new Date());
+    let written = 0;
+
+    const users = await db.collection('users').listDocuments();
+    for (const userRef of users) {
+      const [invSnap, liabSnap] = await Promise.all([
+        userRef.collection('investments').get(),
+        userRef.collection('liabilities').get(),
+      ]);
+      if (invSnap.empty && liabSnap.empty) continue;
+
+      const assetsByClass: Record<string, number> = {};
+      const liabilitiesByKind: Record<string, number> = {};
+      const netWorthByMember: Record<string, number> = {};
+      let totalAssets = 0;
+      let totalLiabilities = 0;
+      let superValue = 0;
+
+      for (const d of invSnap.docs) {
+        const inv = d.data() as InvestmentDoc;
+        const value = typeof inv.currentValue === 'number' ? inv.currentValue : 0;
+        if (inv.type === 'Superannuation') superValue += value;
+        const cls = inv.type || 'Other';
+        assetsByClass[cls] = (assetsByClass[cls] || 0) + value;
+        totalAssets += value;
+        const ownerKey = inv.owner || JOINT_KEY;
+        netWorthByMember[ownerKey] = (netWorthByMember[ownerKey] || 0) + value;
+      }
+
+      for (const d of liabSnap.docs) {
+        const liab = d.data() as LiabilityDoc;
+        const balance = typeof liab.currentBalance === 'number' ? liab.currentBalance : 0;
+        totalLiabilities += balance;
+        const kind = liab.kind || 'other';
+        liabilitiesByKind[kind] = (liabilitiesByKind[kind] || 0) + balance;
+        const ownerKey = liab.owner || JOINT_KEY;
+        netWorthByMember[ownerKey] = (netWorthByMember[ownerKey] || 0) - balance;
+      }
+
+      const snap = {
+        id: month,
+        capturedAt: new Date().toISOString(),
+        totalAssets,
+        totalLiabilities,
+        netWorth: totalAssets - totalLiabilities,
+        assetsByClass,
+        liabilitiesByKind,
+        netWorthByMember,
+        superValue,
+      };
+      await userRef.collection('networth-history').doc(month).set(snap, { merge: true });
+      written += 1;
+    }
+
+    logger.info('networthSnapshot wrote', { written, month });
+  },
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,3 +12,4 @@ export { expensesCategoriseWorker } from './handlers/expenses-categorise-worker'
 export { cashflowImport } from './handlers/cashflow-import';
 export { notificationsCleanup } from './handlers/notifications-cleanup';
 export { budgetsAlerts } from './handlers/budgets-alerts';
+export { networthSnapshot } from './handlers/networth-snapshot';

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -11,3 +11,4 @@ export { expensesReanalyse } from './handlers/expenses-reanalyse';
 export { expensesCategoriseWorker } from './handlers/expenses-categorise-worker';
 export { cashflowImport } from './handlers/cashflow-import';
 export { notificationsCleanup } from './handlers/notifications-cleanup';
+export { budgetsAlerts } from './handlers/budgets-alerts';

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,9 @@
 import '@testing-library/jest-dom';
+
+// jsdom (jest 30) doesn't ship a global `fetch`. The Firebase Auth Node entry
+// reads it at module evaluation time, so provide a no-op polyfill here so
+// tests can import modules that transitively touch firebase/auth without
+// needing per-test mocks.
+if (typeof globalThis.fetch === 'undefined') {
+  globalThis.fetch = (() => Promise.reject(new Error('fetch is not stubbed in this test'))) as typeof fetch;
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,9 +1,22 @@
 import '@testing-library/jest-dom';
 
-// jsdom (jest 30) doesn't ship a global `fetch`. The Firebase Auth Node entry
-// reads it at module evaluation time, so provide a no-op polyfill here so
-// tests can import modules that transitively touch firebase/auth without
-// needing per-test mocks.
-if (typeof globalThis.fetch === 'undefined') {
-  globalThis.fetch = (() => Promise.reject(new Error('fetch is not stubbed in this test'))) as typeof fetch;
+// jsdom (jest 30) doesn't ship a global `fetch`/`Response`/`Headers`/`Request`.
+// The Firebase Auth Node entry reads them at module evaluation time, so
+// provide no-op polyfills here so tests can import modules that transitively
+// touch firebase/auth without needing per-test mocks.
+const g = globalThis as unknown as {
+  fetch?: typeof fetch;
+  Response?: typeof Response;
+  Request?: typeof Request;
+  Headers?: typeof Headers;
+};
+
+if (typeof g.fetch === 'undefined') {
+  g.fetch = (() => Promise.reject(new Error('fetch is not stubbed in this test'))) as typeof fetch;
 }
+class StubResponse {}
+class StubRequest {}
+class StubHeaders {}
+if (typeof g.Response === 'undefined') g.Response = StubResponse as unknown as typeof Response;
+if (typeof g.Request === 'undefined') g.Request = StubRequest as unknown as typeof Request;
+if (typeof g.Headers === 'undefined') g.Headers = StubHeaders as unknown as typeof Headers;

--- a/src/__tests__/app-menu.test.ts
+++ b/src/__tests__/app-menu.test.ts
@@ -9,12 +9,12 @@ describe('App Menu', () => {
 
   it('has all navigation items', () => {
     const titles = Menu.filter((item: any) => !item.is_header).map((item: any) => item.title);
-    expect(titles).toEqual(['Dashboard', 'Cashflow', 'Tax', 'Expenses', 'Investment Portfolio', 'Settings']);
+    expect(titles).toEqual(['Dashboard', 'Cashflow', 'Tax', 'Expenses', 'Investment Portfolio', 'Budgets', 'Settings']);
   });
 
   it('has correct paths', () => {
     const paths = Menu.filter((item: any) => !item.is_header).map((item: any) => item.path);
-    expect(paths).toEqual(['/', '/cashflow', '/tax', '/expenses', '/investments', '/settings']);
+    expect(paths).toEqual(['/', '/cashflow', '/tax', '/expenses', '/investments', '/budgets', '/settings']);
   });
 
   it('has icons for all nav items', () => {

--- a/src/__tests__/app-menu.test.ts
+++ b/src/__tests__/app-menu.test.ts
@@ -9,12 +9,12 @@ describe('App Menu', () => {
 
   it('has all navigation items', () => {
     const titles = Menu.filter((item: any) => !item.is_header).map((item: any) => item.title);
-    expect(titles).toEqual(['Dashboard', 'Cashflow', 'Tax', 'Expenses', 'Investment Portfolio', 'Budgets', 'Settings']);
+    expect(titles).toEqual(['Dashboard', 'Cashflow', 'Tax', 'Expenses', 'Investment Portfolio', 'Budgets', 'Net Worth', 'Settings']);
   });
 
   it('has correct paths', () => {
     const paths = Menu.filter((item: any) => !item.is_header).map((item: any) => item.path);
-    expect(paths).toEqual(['/', '/cashflow', '/tax', '/expenses', '/investments', '/budgets', '/settings']);
+    expect(paths).toEqual(['/', '/cashflow', '/tax', '/expenses', '/investments', '/budgets', '/net-worth', '/settings']);
   });
 
   it('has icons for all nav items', () => {

--- a/src/__tests__/budgets-calc.test.ts
+++ b/src/__tests__/budgets-calc.test.ts
@@ -1,0 +1,192 @@
+import {
+  computeProgress,
+  monthKey,
+  nextThresholdToAlert,
+  previousMonth,
+  rolloverInForMonth,
+  spendForMonth,
+} from '@/lib/budgets-calc';
+import type { Budget } from '@/lib/budgets-types';
+import type { Expense } from '@/lib/types';
+
+const expense = (overrides: Partial<Expense>): Expense => ({
+  id: 'e' + Math.random(),
+  date: '2026-04-15',
+  description: 'X',
+  amount: 0,
+  category: 'Other Deductions',
+  financialYear: '2025-2026',
+  ...overrides,
+});
+
+const groceries: Budget = {
+  id: 'g',
+  scope: 'spending-category',
+  category: 'Groceries',
+  amount: 800,
+  period: 'monthly',
+  startMonth: '2026-01',
+  rolloverUnused: false,
+  alertThresholds: [0.8, 1.0, 1.2],
+};
+
+describe('monthKey + previousMonth', () => {
+  it('formats Date to YYYY-MM', () => {
+    expect(monthKey(new Date(2026, 3, 26))).toBe('2026-04');
+  });
+
+  it('rolls over the year boundary', () => {
+    expect(previousMonth('2026-01')).toBe('2025-12');
+    expect(previousMonth('2026-04')).toBe('2026-03');
+  });
+});
+
+describe('spendForMonth', () => {
+  it('sums only expenses matching scope and month', () => {
+    const expenses: Expense[] = [
+      expense({ date: '2026-04-01', amount: 120, spendingCategory: 'Groceries' }),
+      expense({ date: '2026-04-15', amount: 80, spendingCategory: 'Groceries' }),
+      expense({ date: '2026-03-30', amount: 99, spendingCategory: 'Groceries' }), // wrong month
+      expense({ date: '2026-04-15', amount: 50, spendingCategory: 'Cafe' }),       // wrong category
+    ];
+    expect(spendForMonth(groceries, expenses, '2026-04')).toBe(200);
+  });
+
+  it('overall scope counts every expense in the month', () => {
+    const overall: Budget = { ...groceries, scope: 'overall', category: undefined };
+    const expenses: Expense[] = [
+      expense({ date: '2026-04-01', amount: 100, spendingCategory: 'Groceries' }),
+      expense({ date: '2026-04-15', amount: 250, spendingCategory: 'Cafe' }),
+      expense({ date: '2026-03-30', amount: 999 }), // out of month
+    ];
+    expect(spendForMonth(overall, expenses, '2026-04')).toBe(350);
+  });
+
+  it('sub-category scope filters to the exact pair', () => {
+    const sub: Budget = {
+      ...groceries,
+      scope: 'spending-sub-category',
+      subCategory: 'Coffee',
+    };
+    const expenses: Expense[] = [
+      expense({ date: '2026-04-01', amount: 12, spendingCategory: 'Groceries', spendingSubCategory: 'Coffee' }),
+      expense({ date: '2026-04-15', amount: 12, spendingCategory: 'Groceries', spendingSubCategory: 'Tea' }), // wrong sub
+      expense({ date: '2026-04-15', amount: 12, spendingCategory: 'Cafe', spendingSubCategory: 'Coffee' }),    // wrong cat
+    ];
+    expect(spendForMonth(sub, expenses, '2026-04')).toBe(12);
+  });
+
+  it('ignores rows with missing date or non-numeric amount', () => {
+    const expenses = [
+      expense({ date: undefined as unknown as string, amount: 100 }),
+      expense({ date: '2026-04-01', amount: NaN }),
+      expense({ date: '2026-04-01', amount: 50, spendingCategory: 'Groceries' }),
+    ];
+    expect(spendForMonth(groceries, expenses, '2026-04')).toBe(50);
+  });
+});
+
+describe('rollover', () => {
+  it('returns 0 when rollover is disabled', () => {
+    const expenses: Expense[] = [
+      expense({ date: '2026-03-15', amount: 100, spendingCategory: 'Groceries' }),
+    ];
+    expect(rolloverInForMonth(groceries, expenses, '2026-04')).toBe(0);
+  });
+
+  it('rolls forward unspent budget when enabled', () => {
+    const b: Budget = { ...groceries, rolloverUnused: true };
+    const expenses: Expense[] = [
+      expense({ date: '2026-03-15', amount: 500, spendingCategory: 'Groceries' }), // 300 unspent
+    ];
+    expect(rolloverInForMonth(b, expenses, '2026-04')).toBe(300);
+  });
+
+  it('caps rollover at 1× budget amount', () => {
+    const b: Budget = { ...groceries, amount: 800, rolloverUnused: true };
+    // Even with no spend, rollover is at most 800.
+    const expenses: Expense[] = [];
+    expect(rolloverInForMonth(b, expenses, '2026-04')).toBe(800);
+  });
+
+  it('returns 0 when previous month overspent (no negative carry)', () => {
+    const b: Budget = { ...groceries, rolloverUnused: true };
+    const expenses: Expense[] = [
+      expense({ date: '2026-03-10', amount: 1100, spendingCategory: 'Groceries' }),
+    ];
+    expect(rolloverInForMonth(b, expenses, '2026-04')).toBe(0);
+  });
+
+  it('returns 0 in or before the budget start month', () => {
+    const b: Budget = { ...groceries, rolloverUnused: true, startMonth: '2026-04' };
+    expect(rolloverInForMonth(b, [], '2026-04')).toBe(0);
+    expect(rolloverInForMonth(b, [], '2026-03')).toBe(0);
+  });
+});
+
+describe('computeProgress', () => {
+  it('classifies levels correctly and caps the visual ratio at 1.5', () => {
+    const p1 = computeProgress(groceries, [expense({ amount: 100, spendingCategory: 'Groceries' })], '2026-04');
+    expect(p1.level).toBe('green');
+
+    const p2 = computeProgress(groceries, [expense({ amount: 700, spendingCategory: 'Groceries' })], '2026-04');
+    expect(p2.level).toBe('amber');
+
+    const p3 = computeProgress(groceries, [expense({ amount: 2000, spendingCategory: 'Groceries' })], '2026-04');
+    expect(p3.level).toBe('red');
+    expect(p3.ratio).toBe(1.5);
+  });
+
+  it('includes rollover in the effective cap', () => {
+    const b: Budget = { ...groceries, rolloverUnused: true };
+    const prevMonth = expense({ date: '2026-03-10', amount: 600, spendingCategory: 'Groceries' });
+    const thisMonth = expense({ date: '2026-04-10', amount: 200, spendingCategory: 'Groceries' });
+    const p = computeProgress(b, [prevMonth, thisMonth], '2026-04');
+    expect(p.rolloverIn).toBe(200);
+    expect(p.effectiveCap).toBe(1000);
+    expect(p.spent).toBe(200);
+    expect(p.level).toBe('green');
+  });
+});
+
+describe('nextThresholdToAlert', () => {
+  it('returns the highest crossed threshold on first eval', () => {
+    expect(nextThresholdToAlert(groceries, 700, 800, '2026-04')).toBe(0.8);
+    expect(nextThresholdToAlert(groceries, 800, 800, '2026-04')).toBe(1.0);
+    expect(nextThresholdToAlert(groceries, 1000, 800, '2026-04')).toBe(1.2);
+  });
+
+  it('returns null when no threshold has been hit', () => {
+    expect(nextThresholdToAlert(groceries, 100, 800, '2026-04')).toBeNull();
+  });
+
+  it('does not re-fire the same threshold within the same month', () => {
+    const after80: Budget = {
+      ...groceries,
+      lastAlertedMonth: '2026-04',
+      lastAlertedThreshold: 0.8,
+    };
+    expect(nextThresholdToAlert(after80, 700, 800, '2026-04')).toBeNull();
+    expect(nextThresholdToAlert(after80, 800, 800, '2026-04')).toBe(1.0);
+  });
+
+  it('resets on a new month so 80% can fire again', () => {
+    const lastMonth: Budget = {
+      ...groceries,
+      lastAlertedMonth: '2026-03',
+      lastAlertedThreshold: 1.2,
+    };
+    expect(nextThresholdToAlert(lastMonth, 700, 800, '2026-04')).toBe(0.8);
+  });
+
+  it('honours custom thresholds and returns the highest crossed', () => {
+    const tight: Budget = { ...groceries, alertThresholds: [0.5, 0.9] };
+    expect(nextThresholdToAlert(tight, 480, 800, '2026-04')).toBe(0.5); // ratio 0.6 → only 0.5 crossed
+    expect(nextThresholdToAlert(tight, 720, 800, '2026-04')).toBe(0.9); // ratio 0.9 → both crossed, return 0.9
+  });
+
+  it('falls back to the defaults when alertThresholds is empty', () => {
+    const empty: Budget = { ...groceries, alertThresholds: [] };
+    expect(nextThresholdToAlert(empty, 1000, 800, '2026-04')).toBe(1.2);
+  });
+});

--- a/src/__tests__/budgets-helpers.test.ts
+++ b/src/__tests__/budgets-helpers.test.ts
@@ -1,0 +1,95 @@
+import {
+  describeBudget,
+  describeScope,
+  thresholdLabel,
+} from '@/lib/budgets-calc';
+import {
+  DEFAULT_SPENDING_CATEGORIES,
+  SPENDING_COLORS,
+  SPENDING_ICONS,
+  spendingColor,
+  spendingIcon,
+} from '@/lib/spending-categories';
+import {
+  LIABILITY_KIND_ICON,
+  LIABILITY_KIND_LABEL,
+} from '@/lib/networth-types';
+import type { Budget } from '@/lib/budgets-types';
+
+const base: Budget = {
+  id: 'b',
+  scope: 'spending-category',
+  category: 'Groceries',
+  amount: 800,
+  period: 'monthly',
+  startMonth: '2026-01',
+  rolloverUnused: false,
+  alertThresholds: [0.8, 1.0, 1.2],
+};
+
+describe('describeBudget', () => {
+  it('handles overall scope', () => {
+    expect(describeBudget({ ...base, scope: 'overall', category: undefined })).toBe('Overall monthly spending');
+  });
+
+  it('returns the category name for spending-category scope', () => {
+    expect(describeBudget(base)).toBe('Groceries');
+  });
+
+  it('chains category and sub-category for sub scope', () => {
+    expect(describeBudget({ ...base, scope: 'spending-sub-category', subCategory: 'Coffee' })).toBe('Groceries → Coffee');
+  });
+
+  it('falls back to a sensible label when category is missing', () => {
+    expect(describeBudget({ ...base, category: undefined })).toBe('Uncategorised');
+  });
+});
+
+describe('describeScope + thresholdLabel', () => {
+  it('describeScope maps every scope', () => {
+    expect(describeScope('overall')).toBe('Overall');
+    expect(describeScope('spending-category')).toBe('Category');
+    expect(describeScope('spending-sub-category')).toBe('Sub-category');
+  });
+
+  it('thresholdLabel renders fractions as integer percent', () => {
+    expect(thresholdLabel(0.8)).toBe('80%');
+    expect(thresholdLabel(1)).toBe('100%');
+    expect(thresholdLabel(1.2)).toBe('120%');
+  });
+});
+
+describe('spending-categories helpers', () => {
+  it('exposes 21 categories with paired icon + colour', () => {
+    expect(DEFAULT_SPENDING_CATEGORIES).toHaveLength(21);
+    for (const c of DEFAULT_SPENDING_CATEGORIES) {
+      expect(SPENDING_ICONS[c]).toMatch(/^fa-/);
+      expect(SPENDING_COLORS[c]).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+
+  it('spendingIcon falls back for unknown categories', () => {
+    expect(spendingIcon('Groceries')).toBe('fa-cart-shopping');
+    expect(spendingIcon('totally-unknown')).toBe('fa-ellipsis');
+    expect(spendingIcon(undefined)).toBe('fa-ellipsis');
+    expect(spendingIcon(null)).toBe('fa-ellipsis');
+  });
+
+  it('spendingColor falls back for unknown categories', () => {
+    expect(spendingColor('Groceries')).toBe('#20c997');
+    expect(spendingColor('totally-unknown')).toBe('#6c757d');
+    expect(spendingColor(undefined)).toBe('#6c757d');
+  });
+});
+
+describe('liability label/icon maps', () => {
+  it('covers every liability kind', () => {
+    const kinds: (keyof typeof LIABILITY_KIND_LABEL)[] = [
+      'mortgage', 'personal-loan', 'car-loan', 'student-loan', 'credit-card', 'other',
+    ];
+    for (const k of kinds) {
+      expect(LIABILITY_KIND_LABEL[k]).toBeTruthy();
+      expect(LIABILITY_KIND_ICON[k]).toMatch(/^fa-/);
+    }
+  });
+});

--- a/src/__tests__/budgets-page-smoke.test.tsx
+++ b/src/__tests__/budgets-page-smoke.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Budget } from '@/lib/budgets-types';
+import type { Expense } from '@/lib/types';
+
+const watchBudgetsCb: { fn?: (b: Budget[]) => void } = {};
+const mockListExpenses = jest.fn<Promise<Expense[]>, [string]>().mockResolvedValue([]);
+const mockAddBudget = jest.fn().mockResolvedValue({ id: 'new', amount: 100 });
+const mockUpdateBudget = jest.fn().mockResolvedValue(undefined);
+const mockDeleteBudget = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@/lib/firebase', () => ({ auth: null, db: null, app: null, functions: null }));
+
+jest.mock('@/lib/budgets-repo', () => ({
+  watchBudgets: (cb: (b: Budget[]) => void) => {
+    watchBudgetsCb.fn = cb;
+    cb([]);
+    return () => {};
+  },
+  addBudget: (...args: unknown[]) => mockAddBudget(...args),
+  updateBudget: (...args: unknown[]) => mockUpdateBudget(...args),
+  deleteBudget: (...args: unknown[]) => mockDeleteBudget(...args),
+  listBudgets: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/lib/expenses-repo', () => ({
+  listExpenses: (fy: string) => mockListExpenses(fy),
+}));
+
+jest.mock('@/lib/use-preferences', () => {
+  const { DEFAULT_PREFERENCES } = jest.requireActual('@/lib/user-preferences-types');
+  return {
+    usePreferences: () => ({ prefs: DEFAULT_PREFERENCES, ready: true, update: jest.fn() }),
+  };
+});
+
+import BudgetsPage from '@/app/budgets/page';
+
+beforeEach(() => {
+  watchBudgetsCb.fn = undefined;
+  mockListExpenses.mockClear().mockResolvedValue([]);
+  mockAddBudget.mockClear().mockResolvedValue({ id: 'new', amount: 100 });
+});
+
+describe('/budgets page (smoke)', () => {
+  it('renders the page header', async () => {
+    render(<BudgetsPage />);
+    await waitFor(() => expect(screen.getByText('Budgets')).toBeInTheDocument());
+  });
+
+  it('renders the form action button so the new-budget panel mounts', async () => {
+    render(<BudgetsPage />);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Add budget/i })).toBeInTheDocument(),
+    );
+  });
+
+  it('renders a budget delivered via the watcher', async () => {
+    render(<BudgetsPage />);
+    await waitFor(() => expect(watchBudgetsCb.fn).toBeTruthy());
+    const budget: Budget = {
+      id: 'g',
+      scope: 'spending-category',
+      category: 'Groceries',
+      amount: 800,
+      period: 'monthly',
+      startMonth: '2026-01',
+      rolloverUnused: true,
+      alertThresholds: [0.8, 1.0, 1.2],
+    };
+    watchBudgetsCb.fn!([budget]);
+    await waitFor(() => expect(screen.getByText('Groceries')).toBeInTheDocument());
+    expect(screen.getByText('rollover')).toBeInTheDocument();
+  });
+
+  it('submits the default form (Groceries / $500) and calls addBudget', async () => {
+    render(<BudgetsPage />);
+    const submit = await screen.findByRole('button', { name: /Add budget/i });
+    fireEvent.click(submit);
+    await waitFor(() => expect(mockAddBudget).toHaveBeenCalledTimes(1));
+    expect(mockAddBudget.mock.calls[0][0]).toMatchObject({
+      scope: 'spending-category',
+      category: 'Groceries',
+      amount: 500,
+    });
+  });
+});

--- a/src/__tests__/budgets-repo.test.ts
+++ b/src/__tests__/budgets-repo.test.ts
@@ -1,0 +1,134 @@
+import type { Budget } from '@/lib/budgets-types';
+
+describe('budgets-repo guest mode', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    if (typeof window !== 'undefined') window.localStorage.setItem('fd_guest', '1');
+  });
+  afterAll(() => {
+    if (typeof window !== 'undefined') window.localStorage.removeItem('fd_guest');
+  });
+
+  it('round-trips through the guest store (add/list/update/delete)', async () => {
+    const repo = await import('@/lib/budgets-repo');
+    const initial = await repo.listBudgets();
+    expect(initial).toEqual([]);
+
+    const added = await repo.addBudget({
+      scope: 'spending-category',
+      category: 'Groceries',
+      amount: 600,
+      period: 'monthly',
+      startMonth: '2026-04',
+      rolloverUnused: false,
+      alertThresholds: [0.8, 1, 1.2],
+    });
+    expect(added.id).toBeTruthy();
+
+    const listed = await repo.listBudgets();
+    expect(listed).toHaveLength(1);
+
+    await repo.updateBudget(added.id, { amount: 700 });
+    expect((await repo.listBudgets())[0].amount).toBe(700);
+
+    await repo.deleteBudget(added.id);
+    expect(await repo.listBudgets()).toEqual([]);
+  });
+
+  it('watchBudgets in guest mode delivers the current snapshot once', async () => {
+    const repo = await import('@/lib/budgets-repo');
+    await repo.addBudget({
+      scope: 'overall',
+      amount: 5000,
+      period: 'monthly',
+      startMonth: '2026-04',
+      rolloverUnused: false,
+      alertThresholds: [0.8, 1, 1.2],
+    });
+    const captured: Budget[][] = [];
+    const off = repo.watchBudgets(b => captured.push(b));
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toHaveLength(1);
+    off();
+  });
+});
+
+describe('budgets-repo Firestore mode', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    if (typeof window !== 'undefined') window.localStorage.removeItem('fd_guest');
+  });
+
+  it('list / add / update / delete use the right Firestore primitives', async () => {
+    const collection = jest.fn(() => ({ collectionRef: true }));
+    const docFn = jest.fn(() => ({ id: 'auto-id' }));
+    const queryFn = jest.fn((c, ...rest) => ({ q: true, c, rest }));
+    const orderBy = jest.fn(name => ({ orderBy: name }));
+    const getDocs = jest.fn().mockResolvedValue({
+      docs: [{ id: 'b1', data: () => ({ scope: 'overall', amount: 100 }) }],
+    });
+    const setDoc = jest.fn().mockResolvedValue(undefined);
+    const updateDoc = jest.fn().mockResolvedValue(undefined);
+    const deleteDoc = jest.fn().mockResolvedValue(undefined);
+    const onSnapshot = jest.fn();
+
+    jest.doMock('firebase/firestore', () => ({
+      collection, doc: docFn, query: queryFn, orderBy,
+      getDocs, setDoc, updateDoc, deleteDoc, onSnapshot,
+    }));
+    jest.doMock('@/lib/firebase', () => ({
+      auth: { currentUser: { email: 'me@example.com' } },
+      db: { __db: true },
+      app: null,
+      functions: null,
+    }));
+
+    const repo = await import('@/lib/budgets-repo');
+    const list = await repo.listBudgets();
+    expect(getDocs).toHaveBeenCalledTimes(1);
+    expect(list).toEqual([{ id: 'b1', scope: 'overall', amount: 100 }]);
+
+    await repo.addBudget({
+      scope: 'overall',
+      amount: 200,
+      period: 'monthly',
+      startMonth: '2026-04',
+      rolloverUnused: false,
+      alertThresholds: [0.8, 1, 1.2],
+    });
+    expect(setDoc).toHaveBeenCalledTimes(1);
+
+    await repo.updateBudget('b1', { amount: 250 });
+    expect(updateDoc).toHaveBeenCalledTimes(1);
+
+    await repo.deleteBudget('b1');
+    expect(deleteDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('watchBudgets subscribes via onSnapshot and emits []  on error', async () => {
+    const collection = jest.fn(() => ({}));
+    const queryFn = jest.fn(() => ({}));
+    const orderBy = jest.fn();
+    const onSnapshot = jest.fn((_q, _onNext, onErr) => {
+      // simulate Firestore error path
+      onErr(new Error('permission'));
+      return () => {};
+    });
+    jest.doMock('firebase/firestore', () => ({
+      collection, query: queryFn, orderBy, onSnapshot,
+      doc: jest.fn(), getDocs: jest.fn(), setDoc: jest.fn(), updateDoc: jest.fn(), deleteDoc: jest.fn(),
+    }));
+    jest.doMock('@/lib/firebase', () => ({
+      auth: { currentUser: { email: 'me@example.com' } },
+      db: { __db: true },
+      app: null,
+      functions: null,
+    }));
+
+    const repo = await import('@/lib/budgets-repo');
+    const captured: Budget[][] = [];
+    const off = repo.watchBudgets(b => captured.push(b));
+    expect(captured).toEqual([[]]);
+    expect(typeof off).toBe('function');
+  });
+});

--- a/src/__tests__/dashboard-widgets.test.tsx
+++ b/src/__tests__/dashboard-widgets.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import type { Budget } from '@/lib/budgets-types';
+import type { Liability, NetWorthSnapshot } from '@/lib/networth-types';
+import type { Investment, Expense } from '@/lib/types';
+
+const watchBudgetsCb: { fn?: (b: Budget[]) => void } = {};
+const mockListExpenses = jest.fn<Promise<Expense[]>, [string]>();
+const mockListInvestments = jest.fn<Promise<Investment[]>, []>();
+const mockListLiabilities = jest.fn<Promise<Liability[]>, []>();
+const mockListHistory = jest.fn<Promise<NetWorthSnapshot[]>, []>();
+
+jest.mock('@/lib/firebase', () => ({ auth: null, db: null, app: null, functions: null }));
+
+jest.mock('@/lib/budgets-repo', () => ({
+  watchBudgets: (cb: (b: Budget[]) => void) => {
+    watchBudgetsCb.fn = cb;
+    cb([]);
+    return () => {};
+  },
+}));
+
+jest.mock('@/lib/expenses-repo', () => ({
+  listExpenses: (fy: string) => mockListExpenses(fy),
+}));
+
+jest.mock('@/lib/investments-repo', () => ({
+  listInvestments: () => mockListInvestments(),
+}));
+
+jest.mock('@/lib/liabilities-repo', () => ({
+  listLiabilities: () => mockListLiabilities(),
+}));
+
+jest.mock('@/lib/networth-history-repo', () => ({
+  listNetWorthHistory: () => mockListHistory(),
+}));
+
+jest.mock('@/lib/use-preferences', () => {
+  const { DEFAULT_PREFERENCES } = jest.requireActual('@/lib/user-preferences-types');
+  return {
+    usePreferences: () => ({ prefs: DEFAULT_PREFERENCES, ready: true, update: jest.fn() }),
+  };
+});
+
+jest.mock('next/link', () => {
+  return function MockLink({ children, href }: { children: React.ReactNode; href: string }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+import BudgetsWidget from '@/components/budgets-widget';
+import NetWorthWidget from '@/components/networth-widget';
+
+beforeEach(() => {
+  watchBudgetsCb.fn = undefined;
+  mockListExpenses.mockReset().mockResolvedValue([]);
+  mockListInvestments.mockReset().mockResolvedValue([]);
+  mockListLiabilities.mockReset().mockResolvedValue([]);
+  mockListHistory.mockReset().mockResolvedValue([]);
+});
+
+describe('BudgetsWidget', () => {
+  it('renders nothing when no budgets are configured', async () => {
+    const { container } = render(<BudgetsWidget />);
+    await waitFor(() => expect(mockListExpenses).toHaveBeenCalled());
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders the top 3 budgets sorted by ratio', async () => {
+    render(<BudgetsWidget />);
+    await waitFor(() => expect(watchBudgetsCb.fn).toBeTruthy());
+    const budgets: Budget[] = [
+      { id: 'a', scope: 'spending-category', category: 'Groceries', amount: 800, period: 'monthly', startMonth: '2026-01', rolloverUnused: false, alertThresholds: [0.8, 1, 1.2] },
+      { id: 'b', scope: 'spending-category', category: 'Cafe', amount: 200, period: 'monthly', startMonth: '2026-01', rolloverUnused: false, alertThresholds: [0.8, 1, 1.2] },
+    ];
+    watchBudgetsCb.fn!(budgets);
+    await waitFor(() => expect(screen.getByText('Budgets · top 3')).toBeInTheDocument());
+    expect(screen.getByText('Groceries')).toBeInTheDocument();
+    expect(screen.getByText('Cafe')).toBeInTheDocument();
+  });
+});
+
+describe('NetWorthWidget', () => {
+  it('renders nothing when nothing is tracked', async () => {
+    const { container } = render(<NetWorthWidget />);
+    await waitFor(() => expect(mockListInvestments).toHaveBeenCalled());
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders with investments + liabilities + history delta', async () => {
+    mockListInvestments.mockResolvedValue([
+      { id: 'i1', name: 'X', type: 'Australian Shares', currentValue: 100_000, costBasis: 80_000 },
+    ]);
+    mockListLiabilities.mockResolvedValue([
+      { id: 'l1', name: 'CC', kind: 'credit-card', currentBalance: 5_000, originalAmount: 5_000 },
+    ]);
+    const lastMonthKey = (() => {
+      const d = new Date();
+      d.setMonth(d.getMonth() - 1);
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+    })();
+    mockListHistory.mockResolvedValue([
+      {
+        id: lastMonthKey,
+        capturedAt: new Date().toISOString(),
+        totalAssets: 90_000, totalLiabilities: 5_000, netWorth: 85_000,
+        assetsByClass: {}, liabilitiesByKind: {}, netWorthByMember: {}, superValue: 0,
+      },
+    ]);
+    render(<NetWorthWidget />);
+    await waitFor(() => expect(screen.getByText('Net worth')).toBeInTheDocument());
+    expect(screen.getByText(/since /)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/dashboard.test.tsx
+++ b/src/__tests__/dashboard.test.tsx
@@ -19,6 +19,17 @@ jest.mock('@/lib/family-members-repo', () => ({
   listFamilyMembers: jest.fn().mockResolvedValue([]),
 }));
 
+jest.mock('@/lib/use-preferences', () => {
+  const { DEFAULT_PREFERENCES } = jest.requireActual('@/lib/user-preferences-types');
+  return {
+    usePreferences: () => ({ prefs: DEFAULT_PREFERENCES, ready: true, update: jest.fn() }),
+    PreferencesProvider: ({ children }: { children: React.ReactNode }) => children,
+    getCachedPreferences: () => DEFAULT_PREFERENCES,
+    isAiAdviceAllowed: () => true,
+    isAiContextOptOut: () => false,
+  };
+});
+
 import Dashboard from '@/app/page';
 
 jest.mock('next/link', () => {

--- a/src/__tests__/networth-calc.test.ts
+++ b/src/__tests__/networth-calc.test.ts
@@ -1,0 +1,127 @@
+import {
+  computeNetWorth,
+  deltaVs,
+  NET_WORTH_JOINT_KEY,
+  snapshotFromSummary,
+} from '@/lib/networth-calc';
+import type { Liability } from '@/lib/networth-types';
+import type { Investment } from '@/lib/types';
+
+const inv = (overrides: Partial<Investment>): Investment => ({
+  id: 'i' + Math.random(),
+  name: 'X',
+  type: 'Australian Shares',
+  currentValue: 0,
+  costBasis: 0,
+  ...overrides,
+});
+
+const liab = (overrides: Partial<Liability>): Liability => ({
+  id: 'l' + Math.random(),
+  name: 'X',
+  kind: 'mortgage',
+  currentBalance: 0,
+  originalAmount: 0,
+  ...overrides,
+});
+
+describe('computeNetWorth', () => {
+  it('rolls up assets and liabilities to a household total', () => {
+    const investments = [
+      inv({ type: 'Australian Shares', owner: 'a', currentValue: 50000 }),
+      inv({ type: 'Property', owner: 'a', currentValue: 800000 }),
+      inv({ type: 'Cash / Term Deposit', owner: 'b', currentValue: 25000 }),
+    ];
+    const liabilities = [
+      liab({ kind: 'mortgage', owner: 'a', currentBalance: 600000 }),
+      liab({ kind: 'credit-card', owner: 'b', currentBalance: 5000 }),
+    ];
+    const r = computeNetWorth(investments, liabilities);
+    expect(r.totalAssets).toBe(875000);
+    expect(r.totalLiabilities).toBe(605000);
+    expect(r.netWorth).toBe(270000);
+    expect(r.netWorthByMember.a).toBe(250000); // 50k + 800k - 600k
+    expect(r.netWorthByMember.b).toBe(20000);  // 25k - 5k
+  });
+
+  it('uses the joint key for un-owned items and reconciles to total', () => {
+    const investments = [
+      inv({ type: 'Property', currentValue: 1_000_000 }), // joint
+      inv({ type: 'ETFs', owner: 'a', currentValue: 100_000 }),
+    ];
+    const liabilities = [
+      liab({ kind: 'mortgage', currentBalance: 700_000 }), // joint
+    ];
+    const r = computeNetWorth(investments, liabilities);
+    expect(r.netWorthByMember[NET_WORTH_JOINT_KEY]).toBe(300_000); // 1M - 700k
+    expect(r.netWorthByMember.a).toBe(100_000);
+    const memberSum = Object.values(r.netWorthByMember).reduce((s, v) => s + v, 0);
+    expect(memberSum).toBe(r.netWorth);
+  });
+
+  it('excludes super from totals when requested but still reports superValue', () => {
+    const investments = [
+      inv({ type: 'Superannuation', owner: 'a', currentValue: 200_000 }),
+      inv({ type: 'Australian Shares', owner: 'a', currentValue: 50_000 }),
+    ];
+    const withSuper = computeNetWorth(investments, []);
+    expect(withSuper.totalAssets).toBe(250_000);
+    expect(withSuper.superValue).toBe(200_000);
+
+    const noSuper = computeNetWorth(investments, [], { excludeSuper: true });
+    expect(noSuper.totalAssets).toBe(50_000);
+    expect(noSuper.superValue).toBe(200_000); // still reported
+    expect(noSuper.netWorthByMember.a).toBe(50_000);
+    expect(noSuper.assetsByClass.Superannuation).toBeUndefined();
+  });
+
+  it('skips entries with non-numeric values', () => {
+    const investments = [
+      inv({ type: 'Other', currentValue: NaN as unknown as number }),
+      inv({ type: 'Other', currentValue: 100 }),
+    ];
+    const liabilities = [
+      liab({ kind: 'other', currentBalance: undefined as unknown as number }),
+      liab({ kind: 'other', currentBalance: 50 }),
+    ];
+    const r = computeNetWorth(investments, liabilities);
+    expect(r.totalAssets).toBe(100);
+    expect(r.totalLiabilities).toBe(50);
+  });
+});
+
+describe('deltaVs', () => {
+  it('reports positive deltas with non-zero base', () => {
+    const d = deltaVs(110, 100);
+    expect(d.delta).toBe(10);
+    expect(d.pct).toBeCloseTo(10);
+  });
+
+  it('handles missing previous as zero base', () => {
+    const d = deltaVs(50, undefined);
+    expect(d.previous).toBe(0);
+    expect(d.delta).toBe(50);
+    expect(d.pct).toBe(0);
+  });
+
+  it('treats negative previous correctly (uses absolute value for pct)', () => {
+    const d = deltaVs(0, -100);
+    expect(d.delta).toBe(100);
+    expect(d.pct).toBe(100);
+  });
+});
+
+describe('snapshotFromSummary', () => {
+  it('captures the summary into a snapshot doc', () => {
+    const summary = computeNetWorth(
+      [inv({ type: 'Property', currentValue: 500000 })],
+      [liab({ kind: 'mortgage', currentBalance: 200000 })],
+    );
+    const snap = snapshotFromSummary('2026-04', summary);
+    expect(snap.id).toBe('2026-04');
+    expect(snap.netWorth).toBe(300000);
+    expect(snap.assetsByClass.Property).toBe(500000);
+    expect(snap.liabilitiesByKind.mortgage).toBe(200000);
+    expect(snap.capturedAt).toMatch(/T/); // ISO 8601
+  });
+});

--- a/src/__tests__/networth-page-smoke.test.tsx
+++ b/src/__tests__/networth-page-smoke.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Liability, NetWorthSnapshot } from '@/lib/networth-types';
+import type { Investment, FamilyMember } from '@/lib/types';
+
+const mockListInvestments = jest.fn<Promise<Investment[]>, []>();
+const mockListLiabilities = jest.fn<Promise<Liability[]>, []>();
+const mockListFamilyMembers = jest.fn<Promise<FamilyMember[]>, []>();
+const mockListHistory = jest.fn<Promise<NetWorthSnapshot[]>, []>();
+const mockAddLiability = jest.fn();
+const mockSaveSnapshot = jest.fn();
+
+jest.mock('@/lib/firebase', () => ({ auth: null, db: null, app: null, functions: null }));
+
+jest.mock('@/lib/investments-repo', () => ({ listInvestments: () => mockListInvestments() }));
+jest.mock('@/lib/liabilities-repo', () => ({
+  listLiabilities: () => mockListLiabilities(),
+  addLiability: (...args: unknown[]) => mockAddLiability(...args),
+  updateLiability: jest.fn(),
+  deleteLiability: jest.fn(),
+}));
+jest.mock('@/lib/family-members-repo', () => ({ listFamilyMembers: () => mockListFamilyMembers() }));
+jest.mock('@/lib/networth-history-repo', () => ({
+  listNetWorthHistory: () => mockListHistory(),
+  saveNetWorthSnapshot: (...args: unknown[]) => mockSaveSnapshot(...args),
+}));
+jest.mock('@/lib/use-preferences', () => {
+  const { DEFAULT_PREFERENCES } = jest.requireActual('@/lib/user-preferences-types');
+  return {
+    usePreferences: () => ({ prefs: DEFAULT_PREFERENCES, ready: true, update: jest.fn() }),
+  };
+});
+
+import NetWorthPage from '@/app/net-worth/page';
+
+beforeEach(() => {
+  mockListInvestments.mockReset().mockResolvedValue([]);
+  mockListLiabilities.mockReset().mockResolvedValue([]);
+  mockListFamilyMembers.mockReset().mockResolvedValue([]);
+  mockListHistory.mockReset().mockResolvedValue([]);
+  mockAddLiability.mockReset().mockResolvedValue({ id: 'new' });
+  mockSaveSnapshot.mockReset().mockResolvedValue(undefined);
+});
+
+describe('/net-worth page (smoke)', () => {
+  it('renders the page header', async () => {
+    render(<NetWorthPage />);
+    await waitFor(() => expect(screen.getByText('Net Worth')).toBeInTheDocument());
+  });
+
+  it('exposes the Save snapshot and Add liability buttons', async () => {
+    render(<NetWorthPage />);
+    await screen.findByRole('button', { name: /Save snapshot/i });
+    await screen.findByRole('button', { name: /Add liability/i });
+  });
+
+  it('triggers saveNetWorthSnapshot on click', async () => {
+    render(<NetWorthPage />);
+    const button = await screen.findByRole('button', { name: /Save snapshot/i });
+    fireEvent.click(button);
+    await waitFor(() => expect(mockSaveSnapshot).toHaveBeenCalledTimes(1));
+  });
+
+  it('rejects an unnamed liability submission', async () => {
+    render(<NetWorthPage />);
+    const submit = await screen.findByRole('button', { name: /Add liability/i });
+    fireEvent.click(submit);
+    await waitFor(() =>
+      expect(screen.getByText(/Give the liability a name/i)).toBeInTheDocument(),
+    );
+    expect(mockAddLiability).not.toHaveBeenCalled();
+  });
+
+  it('summarises members + assets when data is provided', async () => {
+    mockListInvestments.mockResolvedValue([
+      { id: 'i1', name: 'CBA', type: 'Australian Shares', currentValue: 50000, costBasis: 40000, owner: 'm1' },
+      { id: 'i2', name: 'Home', type: 'Property', currentValue: 800000, costBasis: 800000 },
+    ]);
+    mockListLiabilities.mockResolvedValue([
+      { id: 'l1', name: 'ANZ', kind: 'mortgage', currentBalance: 600000, originalAmount: 800000 },
+    ]);
+    mockListFamilyMembers.mockResolvedValue([{ id: 'm1', name: 'Alex', salary: 100000 }]);
+
+    render(<NetWorthPage />);
+    // Alex appears in the per-member breakdown and as an owner option in the
+    // form, so just assert there's at least one match.
+    await waitFor(() => expect(screen.getAllByText('Alex').length).toBeGreaterThan(0));
+    expect(screen.getByText('ANZ')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/networth-repos.test.ts
+++ b/src/__tests__/networth-repos.test.ts
@@ -1,0 +1,191 @@
+import type { Liability, NetWorthSnapshot } from '@/lib/networth-types';
+
+describe('liabilities-repo + networth-history-repo guest mode', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    if (typeof window !== 'undefined') window.localStorage.setItem('fd_guest', '1');
+  });
+  afterAll(() => {
+    if (typeof window !== 'undefined') window.localStorage.removeItem('fd_guest');
+  });
+
+  it('liabilities round-trip in guest store', async () => {
+    const repo = await import('@/lib/liabilities-repo');
+    expect(await repo.listLiabilities()).toEqual([]);
+
+    const added = await repo.addLiability({
+      name: 'ANZ home loan',
+      kind: 'mortgage',
+      currentBalance: 600_000,
+      originalAmount: 800_000,
+    });
+    expect(added.id).toBeTruthy();
+
+    await repo.updateLiability(added.id, { currentBalance: 590_000 });
+    expect((await repo.listLiabilities())[0].currentBalance).toBe(590_000);
+
+    await repo.deleteLiability(added.id);
+    expect(await repo.listLiabilities()).toEqual([]);
+  });
+
+  it('networth-history round-trip in guest store', async () => {
+    const repo = await import('@/lib/networth-history-repo');
+    const snap: NetWorthSnapshot = {
+      id: '2026-04',
+      capturedAt: new Date().toISOString(),
+      totalAssets: 1_000_000,
+      totalLiabilities: 600_000,
+      netWorth: 400_000,
+      assetsByClass: { Property: 1_000_000 },
+      liabilitiesByKind: { mortgage: 600_000 },
+      netWorthByMember: { __joint: 400_000 },
+      superValue: 0,
+    };
+    await repo.saveNetWorthSnapshot(snap);
+    expect((await repo.listNetWorthHistory())[0].id).toBe('2026-04');
+
+    // Save a second month so we can verify ordering.
+    await repo.saveNetWorthSnapshot({ ...snap, id: '2026-03', netWorth: 380_000 });
+    const list = await repo.listNetWorthHistory();
+    expect(list.map(h => h.id)).toEqual(['2026-03', '2026-04']);
+
+    // Idempotent merge: re-save same id replaces.
+    await repo.saveNetWorthSnapshot({ ...snap, netWorth: 410_000 });
+    const after = await repo.listNetWorthHistory();
+    expect(after.find(h => h.id === '2026-04')?.netWorth).toBe(410_000);
+  });
+});
+
+describe('liabilities-repo Firestore mode', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    if (typeof window !== 'undefined') window.localStorage.removeItem('fd_guest');
+  });
+
+  it('list/add/update/delete hit the expected primitives', async () => {
+    const collection = jest.fn(() => ({}));
+    const docFn = jest.fn(() => ({ id: 'auto-id' }));
+    const queryFn = jest.fn(() => ({}));
+    const orderBy = jest.fn();
+    const getDocs = jest.fn().mockResolvedValue({
+      docs: [{ id: 'l1', data: () => ({ name: 'M', kind: 'mortgage', currentBalance: 100, originalAmount: 200 }) }],
+    });
+    const setDoc = jest.fn().mockResolvedValue(undefined);
+    const updateDoc = jest.fn().mockResolvedValue(undefined);
+    const deleteDoc = jest.fn().mockResolvedValue(undefined);
+
+    jest.doMock('firebase/firestore', () => ({
+      collection, doc: docFn, query: queryFn, orderBy,
+      getDocs, setDoc, updateDoc, deleteDoc, onSnapshot: jest.fn(),
+    }));
+    jest.doMock('@/lib/firebase', () => ({
+      auth: { currentUser: { email: 'me@example.com' } },
+      db: { __db: true },
+      app: null,
+      functions: null,
+    }));
+
+    const repo = await import('@/lib/liabilities-repo');
+    const list = await repo.listLiabilities();
+    expect(list).toHaveLength(1);
+    expect((list[0] as Liability).kind).toBe('mortgage');
+
+    await repo.addLiability({ name: 'X', kind: 'other', currentBalance: 1, originalAmount: 1 });
+    expect(setDoc).toHaveBeenCalledTimes(1);
+
+    await repo.updateLiability('l1', { currentBalance: 99 });
+    expect(updateDoc).toHaveBeenCalledTimes(1);
+
+    await repo.deleteLiability('l1');
+    expect(deleteDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('listLiabilities falls back to [] when getDocs throws', async () => {
+    jest.doMock('firebase/firestore', () => ({
+      collection: jest.fn(() => ({})),
+      doc: jest.fn(),
+      query: jest.fn(() => ({})),
+      orderBy: jest.fn(),
+      getDocs: jest.fn().mockRejectedValue(new Error('permission')),
+      setDoc: jest.fn(),
+      updateDoc: jest.fn(),
+      deleteDoc: jest.fn(),
+      onSnapshot: jest.fn(),
+    }));
+    jest.doMock('@/lib/firebase', () => ({
+      auth: { currentUser: { email: 'me@example.com' } },
+      db: { __db: true },
+      app: null,
+      functions: null,
+    }));
+    const { listLiabilities } = await import('@/lib/liabilities-repo');
+    await expect(listLiabilities()).resolves.toEqual([]);
+  });
+});
+
+describe('networth-history-repo Firestore mode', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    if (typeof window !== 'undefined') window.localStorage.removeItem('fd_guest');
+  });
+
+  it('list orders by id and save uses setDoc with merge', async () => {
+    const collection = jest.fn(() => ({}));
+    const docFn = jest.fn(() => ({ id: '2026-04' }));
+    const queryFn = jest.fn(() => ({}));
+    const orderBy = jest.fn();
+    const getDocs = jest.fn().mockResolvedValue({
+      docs: [
+        { id: '2026-03', data: () => ({ id: '2026-03', netWorth: 100 }) },
+        { id: '2026-04', data: () => ({ id: '2026-04', netWorth: 110 }) },
+      ],
+    });
+    const setDoc = jest.fn().mockResolvedValue(undefined);
+
+    jest.doMock('firebase/firestore', () => ({
+      collection, doc: docFn, query: queryFn, orderBy,
+      getDocs, setDoc, updateDoc: jest.fn(), deleteDoc: jest.fn(), onSnapshot: jest.fn(),
+    }));
+    jest.doMock('@/lib/firebase', () => ({
+      auth: { currentUser: { email: 'me@example.com' } },
+      db: { __db: true },
+      app: null,
+      functions: null,
+    }));
+
+    const repo = await import('@/lib/networth-history-repo');
+    const list = await repo.listNetWorthHistory();
+    expect(list.map(h => h.id)).toEqual(['2026-03', '2026-04']);
+
+    await repo.saveNetWorthSnapshot({
+      id: '2026-04',
+      capturedAt: new Date().toISOString(),
+      totalAssets: 1, totalLiabilities: 0, netWorth: 1,
+      assetsByClass: {}, liabilitiesByKind: {}, netWorthByMember: {}, superValue: 0,
+    });
+    expect(setDoc).toHaveBeenCalledTimes(1);
+    expect(setDoc.mock.calls[0][2]).toEqual({ merge: true });
+  });
+
+  it('list returns [] on error', async () => {
+    jest.doMock('firebase/firestore', () => ({
+      collection: jest.fn(() => ({})),
+      doc: jest.fn(),
+      query: jest.fn(() => ({})),
+      orderBy: jest.fn(),
+      getDocs: jest.fn().mockRejectedValue(new Error('boom')),
+      setDoc: jest.fn(),
+      updateDoc: jest.fn(),
+      deleteDoc: jest.fn(),
+      onSnapshot: jest.fn(),
+    }));
+    jest.doMock('@/lib/firebase', () => ({
+      auth: { currentUser: { email: 'me@example.com' } },
+      db: { __db: true },
+      app: null,
+      functions: null,
+    }));
+    const { listNetWorthHistory } = await import('@/lib/networth-history-repo');
+    await expect(listNetWorthHistory()).resolves.toEqual([]);
+  });
+});

--- a/src/__tests__/preferences-provider-logout.test.tsx
+++ b/src/__tests__/preferences-provider-logout.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('@/lib/firebase', () => ({ auth: null, db: null, app: null, functions: null }));
+
+jest.mock('@/lib/use-auth-user', () => {
+  const stableAuth = { user: null, ready: true };
+  return { useAuthUser: () => stableAuth };
+});
+
+jest.mock('@/lib/use-guest-mode', () => {
+  const stableGuest = { guest: false, ready: true };
+  return { useGuestMode: () => stableGuest };
+});
+
+const mockGetPrefs = jest.fn();
+jest.mock('@/lib/user-preferences-repo', () => ({
+  getUserPreferences: () => mockGetPrefs(),
+  saveUserPreferences: jest.fn(),
+}));
+
+import { PreferencesProvider, usePreferences } from '@/lib/use-preferences';
+import { getCachedPreferences } from '@/lib/preferences-cache';
+
+function Probe() {
+  const { prefs, ready } = usePreferences();
+  return (
+    <div>
+      <span data-testid="ready">{ready ? 'yes' : 'no'}</span>
+      <span data-testid="homepage">{prefs.defaults.homepage}</span>
+    </div>
+  );
+}
+
+describe('PreferencesProvider when logged out', () => {
+  it('skips the repo call and reports defaults', async () => {
+    render(<PreferencesProvider><Probe /></PreferencesProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('yes'));
+    expect(screen.getByTestId('homepage').textContent).toBe('/');
+    expect(mockGetPrefs).not.toHaveBeenCalled();
+    expect(getCachedPreferences().defaults.homepage).toBe('/');
+  });
+});

--- a/src/__tests__/preferences-provider.test.tsx
+++ b/src/__tests__/preferences-provider.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  DEFAULT_PREFERENCES,
+  type UserPreferences,
+} from '@/lib/user-preferences-types';
+
+const mockGetPrefs = jest.fn<Promise<UserPreferences>, []>();
+const mockSavePrefs = jest.fn<Promise<void>, [UserPreferences]>();
+
+jest.mock('@/lib/firebase', () => ({ auth: null, db: null, app: null, functions: null }));
+
+// Stable references inside the factory so the provider's useEffect doesn't
+// refire on every render (otherwise reload() repeatedly stomps the cache).
+jest.mock('@/lib/use-auth-user', () => {
+  const stableAuth = { user: { email: 'test@example.com' }, ready: true };
+  return { useAuthUser: () => stableAuth };
+});
+
+jest.mock('@/lib/use-guest-mode', () => {
+  const stableGuest = { guest: false, ready: true };
+  return { useGuestMode: () => stableGuest };
+});
+
+jest.mock('@/lib/user-preferences-repo', () => ({
+  getUserPreferences: () => mockGetPrefs(),
+  saveUserPreferences: (p: UserPreferences) => mockSavePrefs(p),
+}));
+
+import { PreferencesProvider, usePreferences } from '@/lib/use-preferences';
+import { getCachedPreferences } from '@/lib/preferences-cache';
+
+function Probe({ patch }: { patch?: Partial<UserPreferences> }) {
+  const { prefs, ready, update } = usePreferences();
+  return (
+    <div>
+      <span data-testid="ready">{ready ? 'yes' : 'no'}</span>
+      <span data-testid="homepage">{prefs.defaults.homepage}</span>
+      <span data-testid="density">{prefs.display.density}</span>
+      <span data-testid="ai">{String(prefs.privacy.aiAdviceEnabled)}</span>
+      <button data-testid="apply" onClick={() => { if (patch) update(patch); }}>apply</button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  mockGetPrefs.mockReset();
+  mockSavePrefs.mockReset().mockResolvedValue(undefined);
+  document.body.classList.remove('density-compact');
+});
+
+describe('PreferencesProvider', () => {
+  it('hydrates prefs from the repo on mount and exposes them via the hook', async () => {
+    const stored: UserPreferences = {
+      ...DEFAULT_PREFERENCES,
+      defaults: { ...DEFAULT_PREFERENCES.defaults, homepage: '/expenses' },
+      privacy: { aiAdviceEnabled: false, aiContextOptOut: true },
+    };
+    mockGetPrefs.mockResolvedValue(stored);
+
+    render(<PreferencesProvider><Probe /></PreferencesProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('yes'));
+    expect(screen.getByTestId('homepage').textContent).toBe('/expenses');
+    expect(screen.getByTestId('ai').textContent).toBe('false');
+    expect(getCachedPreferences().privacy.aiAdviceEnabled).toBe(false);
+  });
+
+  it('falls back to defaults when the repo throws', async () => {
+    mockGetPrefs.mockRejectedValue(new Error('boom'));
+
+    render(<PreferencesProvider><Probe /></PreferencesProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('yes'));
+    expect(screen.getByTestId('homepage').textContent).toBe('/');
+    expect(getCachedPreferences().defaults.homepage).toBe('/');
+  });
+
+  it('toggles the density-compact body class when density changes', async () => {
+    mockGetPrefs.mockResolvedValue({
+      ...DEFAULT_PREFERENCES,
+      display: { ...DEFAULT_PREFERENCES.display, density: 'compact' },
+    });
+
+    render(<PreferencesProvider><Probe /></PreferencesProvider>);
+
+    await waitFor(() => expect(document.body.classList.contains('density-compact')).toBe(true));
+  });
+
+  it('update merges patches, saves through the repo, and refreshes the cache', async () => {
+    mockGetPrefs.mockResolvedValue({ ...DEFAULT_PREFERENCES });
+
+    render(
+      <PreferencesProvider>
+        <Probe patch={{ defaults: { ...DEFAULT_PREFERENCES.defaults, homepage: '/investments' } }} />
+      </PreferencesProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('yes'));
+    fireEvent.click(screen.getByTestId('apply'));
+
+    await waitFor(() => expect(screen.getByTestId('homepage').textContent).toBe('/investments'));
+    expect(mockSavePrefs).toHaveBeenCalledTimes(1);
+    expect(mockSavePrefs.mock.calls[0][0].defaults.homepage).toBe('/investments');
+    expect(getCachedPreferences().defaults.homepage).toBe('/investments');
+  });
+
+  it('update keeps local state when the repo save fails', async () => {
+    mockGetPrefs.mockResolvedValue({ ...DEFAULT_PREFERENCES });
+    mockSavePrefs.mockRejectedValueOnce(new Error('write blocked'));
+
+    render(
+      <PreferencesProvider>
+        <Probe patch={{ display: { ...DEFAULT_PREFERENCES.display, density: 'compact' } }} />
+      </PreferencesProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('yes'));
+    fireEvent.click(screen.getByTestId('apply'));
+
+    await waitFor(() => expect(screen.getByTestId('density').textContent).toBe('compact'));
+  });
+});

--- a/src/__tests__/preferences.test.tsx
+++ b/src/__tests__/preferences.test.tsx
@@ -4,6 +4,12 @@ import {
   withDefaults,
   type UserPreferences,
 } from '@/lib/user-preferences-types';
+import {
+  getCachedPreferences,
+  isAiAdviceAllowed,
+  isAiContextOptOut,
+  setCachedPreferences,
+} from '@/lib/preferences-cache';
 
 const make = (overrides: Partial<UserPreferences['display']> = {}): UserPreferences => ({
   ...DEFAULT_PREFERENCES,
@@ -32,6 +38,22 @@ describe('formatDate', () => {
   it('avoids UTC drift on YYYY-MM-DD strings', () => {
     // 1 Jan 2026 in any TZ should still come out as 01/01/2026.
     expect(formatDate('2026-01-01')).toBe('01/01/2026');
+  });
+
+  it('accepts Date instances', () => {
+    expect(formatDate(new Date(2026, 0, 15))).toBe('15/01/2026');
+  });
+
+  it('accepts numeric timestamps', () => {
+    expect(formatDate(new Date(2026, 0, 15).getTime())).toBe('15/01/2026');
+  });
+
+  it('returns empty for invalid Date instances', () => {
+    expect(formatDate(new Date('totally-not-a-date'))).toBe('');
+  });
+
+  it('returns empty for non-finite timestamp numbers', () => {
+    expect(formatDate(Number.NaN)).toBe('');
   });
 });
 
@@ -68,6 +90,26 @@ describe('formatNumber', () => {
   });
 });
 
+describe('preferences-cache', () => {
+  afterEach(() => setCachedPreferences({ ...DEFAULT_PREFERENCES }));
+
+  it('returns defaults until set', () => {
+    expect(getCachedPreferences()).toEqual(DEFAULT_PREFERENCES);
+    expect(isAiAdviceAllowed()).toBe(true);
+    expect(isAiContextOptOut()).toBe(false);
+  });
+
+  it('reflects mutations made via setCachedPreferences', () => {
+    setCachedPreferences({
+      ...DEFAULT_PREFERENCES,
+      privacy: { aiAdviceEnabled: false, aiContextOptOut: true },
+    });
+    expect(isAiAdviceAllowed()).toBe(false);
+    expect(isAiContextOptOut()).toBe(true);
+    expect(getCachedPreferences().privacy.aiAdviceEnabled).toBe(false);
+  });
+});
+
 describe('withDefaults', () => {
   it('fills missing sections from defaults', () => {
     const merged = withDefaults({});
@@ -87,6 +129,112 @@ describe('withDefaults', () => {
     expect(merged.defaults.defaultFinancialYear).toBe('2024-2025');
     // Untouched section still defaulted.
     expect(merged.display.density).toBe('comfortable');
+  });
+});
+
+// Guest store new helpers -----------------------------------------------------
+
+describe('guest-store user preferences + notifications', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    if (typeof window !== 'undefined') window.localStorage.setItem('fd_guest', '1');
+  });
+  afterAll(() => {
+    if (typeof window !== 'undefined') window.localStorage.removeItem('fd_guest');
+  });
+
+  it('round-trips user preferences through the guest store', async () => {
+    const guest = await import('@/lib/guest-store');
+    expect(guest.getUserPreferences()).toBeUndefined();
+    const next = {
+      ...DEFAULT_PREFERENCES,
+      defaults: { ...DEFAULT_PREFERENCES.defaults, homepage: '/expenses' as const },
+    };
+    guest.setUserPreferences(next);
+    expect(guest.getUserPreferences()).toEqual(next);
+  });
+
+  it('guest-mode user-preferences-repo round-trip', async () => {
+    jest.doMock('@/lib/firebase', () => ({ auth: null, db: null, app: null, functions: null }));
+    const { getUserPreferences, saveUserPreferences } = await import('@/lib/user-preferences-repo');
+    const next = {
+      ...DEFAULT_PREFERENCES,
+      privacy: { aiAdviceEnabled: false, aiContextOptOut: true },
+    };
+    await saveUserPreferences(next);
+    const fetched = await getUserPreferences();
+    expect(fetched.privacy.aiAdviceEnabled).toBe(false);
+    expect(fetched.privacy.aiContextOptOut).toBe(true);
+  });
+
+  it('Firestore-mode repo reads via getDoc and writes via setDoc with merge', async () => {
+    if (typeof window !== 'undefined') window.localStorage.removeItem('fd_guest');
+    const stored = {
+      ...DEFAULT_PREFERENCES,
+      defaults: { ...DEFAULT_PREFERENCES.defaults, homepage: '/tax' as const },
+    };
+    const getDoc = jest.fn().mockResolvedValue({ exists: () => true, data: () => stored });
+    const setDoc = jest.fn().mockResolvedValue(undefined);
+    const docFn = jest.fn(() => ({ /* DocumentReference shape */ } as object));
+
+    jest.doMock('firebase/firestore', () => ({ doc: docFn, getDoc, setDoc }));
+    jest.doMock('@/lib/firebase', () => ({
+      auth: { currentUser: { email: 'me@example.com' } },
+      db: { /* shape doesn't matter — passed straight to mocks */ },
+      app: null,
+      functions: null,
+    }));
+
+    const repo = await import('@/lib/user-preferences-repo');
+    const fetched = await repo.getUserPreferences();
+    expect(fetched.defaults.homepage).toBe('/tax');
+    expect(getDoc).toHaveBeenCalledTimes(1);
+
+    await repo.saveUserPreferences({ ...stored, display: { ...stored.display, density: 'compact' } });
+    expect(setDoc).toHaveBeenCalledTimes(1);
+    expect(setDoc.mock.calls[0][2]).toEqual({ merge: true });
+  });
+
+  it('Firestore-mode getUserPreferences falls back to defaults when getDoc throws', async () => {
+    if (typeof window !== 'undefined') window.localStorage.removeItem('fd_guest');
+    const getDoc = jest.fn().mockRejectedValue(new Error('permission-denied'));
+    jest.doMock('firebase/firestore', () => ({ doc: jest.fn(), getDoc, setDoc: jest.fn() }));
+    jest.doMock('@/lib/firebase', () => ({
+      auth: { currentUser: { email: 'me@example.com' } },
+      db: {},
+      app: null,
+      functions: null,
+    }));
+
+    const { getUserPreferences } = await import('@/lib/user-preferences-repo');
+    const fetched = await getUserPreferences();
+    expect(fetched).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it('addNotification dedupes by id and markRead/markAllRead update readAt', async () => {
+    const guest = await import('@/lib/guest-store');
+    const a = guest.addNotification({ kind: 'system', title: 'A', body: 'first' });
+    const b = guest.addNotification({ kind: 'system', title: 'B', body: 'second', dedupeId: 'pinned' });
+    const dup = guest.addNotification({ kind: 'system', title: 'B-again', body: 'reattempt', dedupeId: 'pinned' });
+    expect(b).toEqual(dup); // same instance returned
+    expect(guest.listNotifications().filter(n => n.id === 'pinned')).toHaveLength(1);
+
+    guest.markNotificationRead(a.id);
+    expect(guest.listNotifications().find(n => n.id === a.id)?.readAt).toBeTruthy();
+
+    guest.markAllNotificationsRead();
+    expect(guest.listNotifications().every(n => n.readAt)).toBe(true);
+  });
+
+  it('round-trips notification preferences', async () => {
+    const guest = await import('@/lib/guest-store');
+    expect(guest.getNotificationPreferences()).toBeUndefined();
+    const prefs = {
+      perKind: { system: 'off' as const },
+      quietHours: { enabled: true, startHHmm: '20:00', endHHmm: '06:00' },
+    };
+    guest.setNotificationPreferences(prefs);
+    expect(guest.getNotificationPreferences()).toEqual(prefs);
   });
 });
 
@@ -121,5 +269,26 @@ describe('AI kill switch', () => {
     jest.doMock('@/lib/guest-store', () => ({ isGuest: () => false }));
     const { fetchDashboardTips } = await import('@/lib/functions-client');
     await expect(fetchDashboardTips()).resolves.toEqual([]);
+  });
+
+  it.each([
+    'streamInvestmentsAdvice',
+    'streamExpensesAdvice',
+    'reanalyseExpenses',
+    'scanReceipt',
+  ] as const)('%s also throws AiDisabledError when AI is disabled', async (fnName) => {
+    jest.doMock('@/lib/firebase', () => ({ auth: null, db: null, app: null, functions: {} }));
+    jest.doMock('@/lib/preferences-cache', () => ({
+      isAiAdviceAllowed: () => false,
+      isAiContextOptOut: () => false,
+      getCachedPreferences: () => DEFAULT_PREFERENCES,
+      setCachedPreferences: () => {},
+    }));
+    jest.doMock('@/lib/guest-store', () => ({ isGuest: () => false }));
+    const mod = await import('@/lib/functions-client');
+    const fn = (mod as unknown as Record<string, (a: unknown, b?: unknown) => Promise<unknown>>)[fnName];
+    // scanReceipt takes two args; the others take one. Both reject before
+    // touching args because the gate runs first.
+    await expect(fn({}, 'image/png')).rejects.toBeInstanceOf(mod.AiDisabledError);
   });
 });

--- a/src/__tests__/preferences.test.tsx
+++ b/src/__tests__/preferences.test.tsx
@@ -1,0 +1,125 @@
+import { formatCurrency, formatDate, formatNumber } from '@/lib/format';
+import {
+  DEFAULT_PREFERENCES,
+  withDefaults,
+  type UserPreferences,
+} from '@/lib/user-preferences-types';
+
+const make = (overrides: Partial<UserPreferences['display']> = {}): UserPreferences => ({
+  ...DEFAULT_PREFERENCES,
+  display: { ...DEFAULT_PREFERENCES.display, ...overrides },
+});
+
+describe('formatDate', () => {
+  it('formats DD/MM/YYYY by default', () => {
+    expect(formatDate('2026-04-26')).toBe('26/04/2026');
+  });
+
+  it('formats YYYY-MM-DD', () => {
+    expect(formatDate('2026-04-26', make({ dateFormat: 'YYYY-MM-DD' }))).toBe('2026-04-26');
+  });
+
+  it('formats D MMM YYYY', () => {
+    expect(formatDate('2026-04-26', make({ dateFormat: 'D MMM YYYY' }))).toBe('26 Apr 2026');
+  });
+
+  it('handles bad input safely', () => {
+    expect(formatDate(null)).toBe('');
+    expect(formatDate(undefined)).toBe('');
+    expect(formatDate('not-a-date')).toBe('');
+  });
+
+  it('avoids UTC drift on YYYY-MM-DD strings', () => {
+    // 1 Jan 2026 in any TZ should still come out as 01/01/2026.
+    expect(formatDate('2026-01-01')).toBe('01/01/2026');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('uses the AU $ symbol by default with no decimals', () => {
+    expect(formatCurrency(1234.56)).toBe('$1,235');
+  });
+
+  it('respects the decimals option', () => {
+    expect(formatCurrency(1234.5, undefined, { decimals: 2 })).toBe('$1,234.50');
+  });
+
+  it('renders negative amounts with a leading sign', () => {
+    expect(formatCurrency(-42, undefined, { decimals: 0 })).toBe('-$42');
+  });
+
+  it('switches to AUD code display when configured', () => {
+    expect(formatCurrency(1000, make({ currencyDisplay: 'code' }))).toBe('AUD 1,000');
+  });
+
+  it('handles non-numeric input gracefully', () => {
+    expect(formatCurrency(undefined)).toBe('$0');
+    expect(formatCurrency(NaN)).toBe('$0');
+  });
+});
+
+describe('formatNumber', () => {
+  it('formats integers with thousands separators', () => {
+    expect(formatNumber(1234567)).toBe('1,234,567');
+  });
+
+  it('respects decimals', () => {
+    expect(formatNumber(0.5, undefined, 2)).toBe('0.50');
+  });
+});
+
+describe('withDefaults', () => {
+  it('fills missing sections from defaults', () => {
+    const merged = withDefaults({});
+    expect(merged.display.dateFormat).toBe('DD/MM/YYYY');
+    expect(merged.privacy.aiAdviceEnabled).toBe(true);
+    expect(merged.defaults.homepage).toBe('/');
+  });
+
+  it('preserves user values when present', () => {
+    const merged = withDefaults({
+      privacy: { aiAdviceEnabled: false, aiContextOptOut: true },
+      defaults: { homepage: '/expenses', defaultFinancialYear: '2024-2025' },
+    });
+    expect(merged.privacy.aiAdviceEnabled).toBe(false);
+    expect(merged.privacy.aiContextOptOut).toBe(true);
+    expect(merged.defaults.homepage).toBe('/expenses');
+    expect(merged.defaults.defaultFinancialYear).toBe('2024-2025');
+    // Untouched section still defaulted.
+    expect(merged.display.density).toBe('comfortable');
+  });
+});
+
+// AI gate ---------------------------------------------------------------------
+
+describe('AI kill switch', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('streamTaxAdvice throws AiDisabledError when prefs disable AI', async () => {
+    jest.doMock('@/lib/firebase', () => ({ auth: null, db: null, app: null, functions: {} }));
+    jest.doMock('@/lib/preferences-cache', () => ({
+      isAiAdviceAllowed: () => false,
+      isAiContextOptOut: () => false,
+      getCachedPreferences: () => DEFAULT_PREFERENCES,
+      setCachedPreferences: () => {},
+    }));
+    jest.doMock('@/lib/guest-store', () => ({ isGuest: () => false }));
+    const { streamTaxAdvice, AiDisabledError } = await import('@/lib/functions-client');
+    await expect(streamTaxAdvice({})).rejects.toBeInstanceOf(AiDisabledError);
+  });
+
+  it('fetchDashboardTips returns [] silently when AI is disabled', async () => {
+    jest.doMock('@/lib/firebase', () => ({ auth: null, db: null, app: null, functions: {} }));
+    jest.doMock('@/lib/preferences-cache', () => ({
+      isAiAdviceAllowed: () => false,
+      isAiContextOptOut: () => false,
+      getCachedPreferences: () => DEFAULT_PREFERENCES,
+      setCachedPreferences: () => {},
+    }));
+    jest.doMock('@/lib/guest-store', () => ({ isGuest: () => false }));
+    const { fetchDashboardTips } = await import('@/lib/functions-client');
+    await expect(fetchDashboardTips()).resolves.toEqual([]);
+  });
+});

--- a/src/app/budgets/page.tsx
+++ b/src/app/budgets/page.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Panel, PanelHeader, PanelBody } from '@/components/panel/panel';
+import { addBudget, deleteBudget, updateBudget, watchBudgets } from '@/lib/budgets-repo';
+import { listExpenses } from '@/lib/expenses-repo';
+import {
+  computeProgress,
+  describeBudget,
+  monthKey,
+  thresholdLabel,
+} from '@/lib/budgets-calc';
+import {
+  DEFAULT_THRESHOLDS,
+  type Budget,
+  type BudgetScope,
+} from '@/lib/budgets-types';
+import { DEFAULT_SPENDING_CATEGORIES, spendingIcon } from '@/lib/spending-categories';
+import { formatCurrency } from '@/lib/format';
+import { usePreferences } from '@/lib/use-preferences';
+import type { Expense } from '@/lib/types';
+
+const LEVEL_BG: Record<'green' | 'amber' | 'red', string> = {
+  green: 'bg-success',
+  amber: 'bg-warning',
+  red: 'bg-danger',
+};
+
+const LEVEL_TEXT: Record<'green' | 'amber' | 'red', string> = {
+  green: 'text-success',
+  amber: 'text-warning',
+  red: 'text-danger',
+};
+
+interface FormState {
+  scope: BudgetScope;
+  category: string;
+  subCategory: string;
+  amount: string;
+  rolloverUnused: boolean;
+}
+
+const EMPTY_FORM: FormState = {
+  scope: 'spending-category',
+  category: 'Groceries',
+  subCategory: '',
+  amount: '500',
+  rolloverUnused: false,
+};
+
+export default function BudgetsPage() {
+  const { prefs } = usePreferences();
+  const [budgets, setBudgets] = useState<Budget[]>([]);
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const month = monthKey(new Date());
+
+  useEffect(() => {
+    const off = watchBudgets(setBudgets);
+    listExpenses('all')
+      .then(setExpenses)
+      .catch(() => setExpenses([]))
+      .finally(() => setLoading(false));
+    return () => off();
+  }, []);
+
+  const progress = useMemo(
+    () => budgets.map(b => computeProgress(b, expenses, month)),
+    [budgets, expenses, month],
+  );
+
+  const sorted = useMemo(
+    () => [...progress].sort((a, b) => b.ratio - a.ratio),
+    [progress],
+  );
+
+  const resetForm = () => { setForm(EMPTY_FORM); setEditingId(null); setError(null); };
+
+  const beginEdit = (b: Budget) => {
+    setEditingId(b.id);
+    setForm({
+      scope: b.scope,
+      category: b.category || 'Groceries',
+      subCategory: b.subCategory || '',
+      amount: String(b.amount),
+      rolloverUnused: b.rolloverUnused,
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const amount = parseFloat(form.amount);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setError('Amount must be a positive number.');
+      return;
+    }
+    if (form.scope !== 'overall' && !form.category) {
+      setError('Pick a category.');
+      return;
+    }
+    if (form.scope === 'spending-sub-category' && !form.subCategory.trim()) {
+      setError('Sub-category cannot be blank for that scope.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const data: Omit<Budget, 'id'> = {
+        scope: form.scope,
+        amount,
+        period: 'monthly',
+        startMonth: month,
+        rolloverUnused: form.rolloverUnused,
+        alertThresholds: [...DEFAULT_THRESHOLDS],
+        ...(form.scope !== 'overall' ? { category: form.category } : {}),
+        ...(form.scope === 'spending-sub-category' ? { subCategory: form.subCategory.trim() } : {}),
+      };
+      if (editingId) {
+        await updateBudget(editingId, data);
+      } else {
+        await addBudget(data);
+      }
+      resetForm();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete this budget?')) return;
+    await deleteBudget(id);
+    if (editingId === id) resetForm();
+  };
+
+  const totalCap = sorted.reduce((sum, p) => sum + p.budget.amount, 0);
+  const totalSpent = sorted.reduce((sum, p) => sum + p.spent, 0);
+  const overall = totalCap > 0 ? Math.min(1.5, totalSpent / totalCap) : 0;
+
+  return (
+    <>
+      <h1 className="page-header">Budgets</h1>
+
+      <div className="row">
+        <div className="col-lg-7 mb-3">
+          <Panel>
+            <PanelHeader noButton>
+              <i className="fa fa-gauge-high me-2"></i>Live Progress · {month}
+            </PanelHeader>
+            <PanelBody>
+              {loading ? (
+                <div className="text-muted small"><i className="fa fa-spinner fa-spin me-1"></i>Loading…</div>
+              ) : sorted.length === 0 ? (
+                <div className="text-muted text-center py-4">
+                  <i className="fa fa-bullseye fa-2x d-block mb-2 text-muted"></i>
+                  No budgets yet — add one on the right to start tracking.
+                </div>
+              ) : (
+                <>
+                  <div className="mb-4">
+                    <div className="d-flex justify-content-between mb-1">
+                      <strong>All budgets combined</strong>
+                      <span>
+                        {formatCurrency(totalSpent, prefs)} / {formatCurrency(totalCap, prefs)}
+                      </span>
+                    </div>
+                    <div className="progress" style={{ height: 10 }}>
+                      <div
+                        className={`progress-bar ${overall >= 1 ? 'bg-danger' : overall >= 0.8 ? 'bg-warning' : 'bg-success'}`}
+                        style={{ width: `${Math.min(100, (overall / 1.5) * 100)}%` }}
+                      />
+                    </div>
+                  </div>
+                  <ul className="list-group list-group-flush">
+                    {sorted.map(p => (
+                      <li key={p.budget.id} className="list-group-item px-0">
+                        <div className="d-flex align-items-start gap-2">
+                          <i className={`fa ${spendingIcon(p.budget.category)} fa-fw mt-1 ${LEVEL_TEXT[p.level]}`}></i>
+                          <div className="flex-grow-1">
+                            <div className="d-flex justify-content-between">
+                              <span>
+                                <strong>{describeBudget(p.budget)}</strong>
+                                {p.budget.rolloverUnused && (
+                                  <span className="badge bg-info ms-2">rollover</span>
+                                )}
+                              </span>
+                              <span className={LEVEL_TEXT[p.level]}>
+                                {formatCurrency(p.spent, prefs)} / {formatCurrency(p.effectiveCap, prefs)}
+                                {p.rolloverIn > 0 && (
+                                  <small className="text-muted ms-1">(+{formatCurrency(p.rolloverIn, prefs)} rollover)</small>
+                                )}
+                              </span>
+                            </div>
+                            <div className="progress mt-1" style={{ height: 8 }}>
+                              <div
+                                className={`progress-bar ${LEVEL_BG[p.level]}`}
+                                style={{ width: `${Math.min(100, (p.ratio / 1.5) * 100)}%` }}
+                              />
+                            </div>
+                            <div className="d-flex justify-content-between mt-1 small text-muted">
+                              <span>
+                                Alerts at {p.budget.alertThresholds.map(thresholdLabel).join(' · ')}
+                              </span>
+                              <span>
+                                <button className="btn btn-link btn-sm p-0 me-2" onClick={() => beginEdit(p.budget)}>Edit</button>
+                                <button className="btn btn-link btn-sm p-0 text-danger" onClick={() => handleDelete(p.budget.id)}>Delete</button>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </PanelBody>
+          </Panel>
+        </div>
+
+        <div className="col-lg-5 mb-3">
+          <Panel>
+            <PanelHeader noButton>
+              <i className={`fa ${editingId ? 'fa-pen-to-square' : 'fa-plus'} me-2`}></i>
+              {editingId ? 'Edit budget' : 'New budget'}
+            </PanelHeader>
+            <PanelBody>
+              <form onSubmit={handleSubmit}>
+                <div className="mb-3">
+                  <label className="form-label small text-muted">Scope</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={form.scope}
+                    onChange={e => setForm(f => ({ ...f, scope: e.target.value as BudgetScope }))}
+                  >
+                    <option value="overall">Overall (all spending)</option>
+                    <option value="spending-category">Category</option>
+                    <option value="spending-sub-category">Sub-category</option>
+                  </select>
+                </div>
+                {form.scope !== 'overall' && (
+                  <div className="mb-3">
+                    <label className="form-label small text-muted">Category</label>
+                    <select
+                      className="form-select form-select-sm"
+                      value={form.category}
+                      onChange={e => setForm(f => ({ ...f, category: e.target.value }))}
+                    >
+                      {DEFAULT_SPENDING_CATEGORIES.map(c => (
+                        <option key={c} value={c}>{c}</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+                {form.scope === 'spending-sub-category' && (
+                  <div className="mb-3">
+                    <label className="form-label small text-muted">Sub-category</label>
+                    <input
+                      type="text"
+                      className="form-control form-control-sm"
+                      placeholder="e.g. Coffee, Streaming"
+                      value={form.subCategory}
+                      onChange={e => setForm(f => ({ ...f, subCategory: e.target.value }))}
+                    />
+                  </div>
+                )}
+                <div className="mb-3">
+                  <label className="form-label small text-muted">Monthly cap (AUD)</label>
+                  <input
+                    type="number"
+                    min={1}
+                    step="0.01"
+                    className="form-control form-control-sm"
+                    value={form.amount}
+                    onChange={e => setForm(f => ({ ...f, amount: e.target.value }))}
+                  />
+                </div>
+                <div className="form-check form-switch mb-3">
+                  <input
+                    className="form-check-input"
+                    id="rollover"
+                    type="checkbox"
+                    checked={form.rolloverUnused}
+                    onChange={e => setForm(f => ({ ...f, rolloverUnused: e.target.checked }))}
+                  />
+                  <label className="form-check-label small" htmlFor="rollover">
+                    Roll unused budget into next month (capped at 1× cap)
+                  </label>
+                </div>
+                {error && <div className="text-danger small mb-2">{error}</div>}
+                <div className="d-flex gap-2">
+                  <button type="submit" className="btn btn-primary btn-sm" disabled={saving}>
+                    {saving ? <><i className="fa fa-spinner fa-spin me-1"></i>Saving</> : editingId ? 'Save changes' : 'Add budget'}
+                  </button>
+                  {editingId && (
+                    <button type="button" className="btn btn-outline-secondary btn-sm" onClick={resetForm}>
+                      Cancel
+                    </button>
+                  )}
+                </div>
+              </form>
+              <hr className="my-4" />
+              <div className="small text-muted">
+                Alerts fire at 80%, 100% and 120% of the effective cap. They route through your in-app
+                bell using the per-kind preference for <strong>Budget alerts</strong> (configurable in
+                Settings → Notifications).
+              </div>
+            </PanelBody>
+          </Panel>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ import TopMenu from '@/components/top-menu/top-menu';
 import Sidebar from '@/components/sidebar/sidebar';
 import SidebarRight from '@/components/sidebar-right/sidebar-right';
 import { AppSettingsProvider, useAppSettings } from '@/config/app-settings';
+import { PreferencesProvider } from '@/lib/use-preferences';
 import { Open_Sans } from 'next/font/google';
 
 const openSans = Open_Sans({
@@ -117,9 +118,11 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
     	</head>
       <body>
 				<AppSettingsProvider>
-					<AuthGate>
-						<Layout>{children}</Layout>
-					</AuthGate>
+					<PreferencesProvider>
+						<AuthGate>
+							<Layout>{children}</Layout>
+						</AuthGate>
+					</PreferencesProvider>
 				</AppSettingsProvider>
       </body>
     </html>

--- a/src/app/net-worth/page.tsx
+++ b/src/app/net-worth/page.tsx
@@ -1,0 +1,474 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Panel, PanelHeader, PanelBody } from '@/components/panel/panel';
+import { listInvestments } from '@/lib/investments-repo';
+import { listFamilyMembers } from '@/lib/family-members-repo';
+import {
+  addLiability,
+  deleteLiability,
+  listLiabilities,
+  updateLiability,
+} from '@/lib/liabilities-repo';
+import {
+  listNetWorthHistory,
+  saveNetWorthSnapshot,
+} from '@/lib/networth-history-repo';
+import {
+  computeNetWorth,
+  deltaVs,
+  NET_WORTH_JOINT_KEY,
+  snapshotFromSummary,
+} from '@/lib/networth-calc';
+import {
+  LIABILITY_KIND_ICON,
+  LIABILITY_KIND_LABEL,
+  type Liability,
+  type LiabilityKind,
+  type NetWorthSnapshot,
+} from '@/lib/networth-types';
+import { formatCurrency } from '@/lib/format';
+import { usePreferences } from '@/lib/use-preferences';
+import { monthKey } from '@/lib/budgets-calc';
+import type { FamilyMember, Investment } from '@/lib/types';
+
+const KIND_OPTIONS: LiabilityKind[] = [
+  'mortgage', 'personal-loan', 'car-loan', 'student-loan', 'credit-card', 'other',
+];
+
+interface LiabilityFormState {
+  name: string;
+  kind: LiabilityKind;
+  owner: string;
+  currentBalance: string;
+  originalAmount: string;
+  interestRate: string;
+  minMonthlyPayment: string;
+}
+
+const EMPTY_LIABILITY_FORM: LiabilityFormState = {
+  name: '',
+  kind: 'mortgage',
+  owner: '',
+  currentBalance: '',
+  originalAmount: '',
+  interestRate: '',
+  minMonthlyPayment: '',
+};
+
+function deltaBadge(delta: number): { className: string; arrow: string } {
+  if (delta > 0) return { className: 'text-success', arrow: '▲' };
+  if (delta < 0) return { className: 'text-danger', arrow: '▼' };
+  return { className: 'text-muted', arrow: '–' };
+}
+
+export default function NetWorthPage() {
+  const { prefs } = usePreferences();
+  const [investments, setInvestments] = useState<Investment[]>([]);
+  const [liabilities, setLiabilities] = useState<Liability[]>([]);
+  const [members, setMembers] = useState<FamilyMember[]>([]);
+  const [history, setHistory] = useState<NetWorthSnapshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [excludeSuper, setExcludeSuper] = useState(false);
+  const [form, setForm] = useState<LiabilityFormState>(EMPTY_LIABILITY_FORM);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [snapshotting, setSnapshotting] = useState(false);
+
+  useEffect(() => {
+    Promise.all([
+      listInvestments(),
+      listLiabilities(),
+      listFamilyMembers(),
+      listNetWorthHistory(),
+    ])
+      .then(([inv, liab, fam, hist]) => {
+        setInvestments(inv);
+        setLiabilities(liab);
+        setMembers(fam);
+        setHistory(hist);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const summary = useMemo(
+    () => computeNetWorth(investments, liabilities, { excludeSuper }),
+    [investments, liabilities, excludeSuper],
+  );
+
+  // Resolve last-month and last-year deltas using stored history when available.
+  const month = monthKey(new Date());
+  const prevMonthKey = useMemo(() => {
+    const [y, m] = month.split('-').map(Number);
+    if (m === 1) return `${y - 1}-12`;
+    return `${y}-${String(m - 1).padStart(2, '0')}`;
+  }, [month]);
+  const prevYearKey = useMemo(() => {
+    const [y, m] = month.split('-').map(Number);
+    return `${y - 1}-${String(m).padStart(2, '0')}`;
+  }, [month]);
+
+  const lastMonthSnap = history.find(h => h.id === prevMonthKey);
+  const lastYearSnap = history.find(h => h.id === prevYearKey);
+
+  const monthDelta = deltaVs(summary.netWorth, lastMonthSnap?.netWorth);
+  const yearDelta = deltaVs(summary.netWorth, lastYearSnap?.netWorth);
+
+  const memberLookup = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const fm of members) m.set(fm.id, fm.name);
+    return m;
+  }, [members]);
+
+  const memberRows = useMemo(() => {
+    const rows = Object.entries(summary.netWorthByMember).map(([key, value]) => ({
+      key,
+      label: key === NET_WORTH_JOINT_KEY ? 'Joint / unassigned' : (memberLookup.get(key) || key),
+      value,
+    }));
+    return rows.sort((a, b) => b.value - a.value);
+  }, [summary.netWorthByMember, memberLookup]);
+
+  const allocationRows = useMemo(() => {
+    const total = summary.totalAssets || 1;
+    return Object.entries(summary.assetsByClass)
+      .map(([cls, value]) => ({ cls, value, pct: (value / total) * 100 }))
+      .sort((a, b) => b.value - a.value);
+  }, [summary.assetsByClass, summary.totalAssets]);
+
+  const handleSnapshot = async () => {
+    setSnapshotting(true);
+    try {
+      const snap = snapshotFromSummary(month, summary);
+      await saveNetWorthSnapshot(snap);
+      const next = await listNetWorthHistory();
+      setHistory(next);
+    } finally {
+      setSnapshotting(false);
+    }
+  };
+
+  const resetForm = () => { setForm(EMPTY_LIABILITY_FORM); setEditingId(null); setError(null); };
+
+  const beginEditLiability = (l: Liability) => {
+    setEditingId(l.id);
+    setForm({
+      name: l.name,
+      kind: l.kind,
+      owner: l.owner || '',
+      currentBalance: String(l.currentBalance),
+      originalAmount: String(l.originalAmount),
+      interestRate: l.interestRate ? String(l.interestRate) : '',
+      minMonthlyPayment: l.minMonthlyPayment ? String(l.minMonthlyPayment) : '',
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const balance = parseFloat(form.currentBalance);
+    const original = parseFloat(form.originalAmount) || balance;
+    if (!form.name.trim()) { setError('Give the liability a name.'); return; }
+    if (!Number.isFinite(balance) || balance < 0) { setError('Balance must be 0 or greater.'); return; }
+    setSaving(true);
+    try {
+      const data: Omit<Liability, 'id'> = {
+        name: form.name.trim(),
+        kind: form.kind,
+        owner: form.owner || undefined,
+        currentBalance: balance,
+        originalAmount: original,
+        ...(form.interestRate ? { interestRate: parseFloat(form.interestRate) } : {}),
+        ...(form.minMonthlyPayment ? { minMonthlyPayment: parseFloat(form.minMonthlyPayment) } : {}),
+      };
+      if (editingId) {
+        await updateLiability(editingId, data);
+      } else {
+        const added = await addLiability(data);
+        setLiabilities(prev => [...prev, added]);
+      }
+      const fresh = await listLiabilities();
+      setLiabilities(fresh);
+      resetForm();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete this liability?')) return;
+    await deleteLiability(id);
+    const fresh = await listLiabilities();
+    setLiabilities(fresh);
+    if (editingId === id) resetForm();
+  };
+
+  const monthDeltaClasses = deltaBadge(monthDelta.delta);
+  const yearDeltaClasses = deltaBadge(yearDelta.delta);
+
+  return (
+    <>
+      <h1 className="page-header">Net Worth</h1>
+
+      {loading ? (
+        <div className="text-muted small"><i className="fa fa-spinner fa-spin me-1"></i>Loading…</div>
+      ) : (
+        <>
+          <Panel className="mb-3">
+            <PanelHeader noButton>
+              <div className="d-flex align-items-center">
+                <i className="fa fa-scale-balanced me-2"></i>Current snapshot
+                <div className="ms-auto d-flex gap-3 align-items-center">
+                  <div className="form-check form-switch mb-0">
+                    <input
+                      className="form-check-input"
+                      id="exclude-super"
+                      type="checkbox"
+                      checked={excludeSuper}
+                      onChange={e => setExcludeSuper(e.target.checked)}
+                    />
+                    <label className="form-check-label small" htmlFor="exclude-super">Exclude super</label>
+                  </div>
+                  <button
+                    className="btn btn-sm btn-outline-primary"
+                    onClick={handleSnapshot}
+                    disabled={snapshotting}
+                  >
+                    {snapshotting ? <><i className="fa fa-spinner fa-spin me-1"></i>Saving</> : <><i className="fa fa-camera me-1"></i>Save snapshot</>}
+                  </button>
+                </div>
+              </div>
+            </PanelHeader>
+            <PanelBody>
+              <div className="row align-items-center mb-3">
+                <div className="col-md-5">
+                  <div className="text-muted small">Net worth</div>
+                  <div className="display-5 fw-bold">{formatCurrency(summary.netWorth, prefs)}</div>
+                  <div className="d-flex gap-3 mt-1 small">
+                    <span className={monthDeltaClasses.className}>
+                      {monthDeltaClasses.arrow} {formatCurrency(monthDelta.delta, prefs)} vs last month
+                      {lastMonthSnap && ` (${monthDelta.pct.toFixed(1)}%)`}
+                    </span>
+                    <span className={yearDeltaClasses.className}>
+                      {yearDeltaClasses.arrow} {formatCurrency(yearDelta.delta, prefs)} vs last year
+                      {lastYearSnap && ` (${yearDelta.pct.toFixed(1)}%)`}
+                    </span>
+                  </div>
+                  {!lastMonthSnap && !lastYearSnap && (
+                    <small className="text-muted d-block mt-1">
+                      Save a snapshot today to start tracking the trend.
+                    </small>
+                  )}
+                </div>
+                <div className="col-md-7">
+                  <div className="row text-center">
+                    <div className="col-4">
+                      <div className="text-muted small">Assets</div>
+                      <div className="h5 mb-0 text-success">{formatCurrency(summary.totalAssets, prefs)}</div>
+                    </div>
+                    <div className="col-4">
+                      <div className="text-muted small">Liabilities</div>
+                      <div className="h5 mb-0 text-danger">{formatCurrency(summary.totalLiabilities, prefs)}</div>
+                    </div>
+                    <div className="col-4">
+                      <div className="text-muted small">Super held</div>
+                      <div className="h5 mb-0">{formatCurrency(summary.superValue, prefs)}</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </PanelBody>
+          </Panel>
+
+          <div className="row">
+            <div className="col-lg-6 mb-3">
+              <Panel>
+                <PanelHeader noButton><i className="fa fa-users me-2"></i>By household member</PanelHeader>
+                <PanelBody>
+                  {memberRows.length === 0 ? (
+                    <div className="text-muted small">Nothing to show — add an investment or liability.</div>
+                  ) : (
+                    <ul className="list-group list-group-flush">
+                      {memberRows.map(row => (
+                        <li key={row.key} className="list-group-item d-flex justify-content-between px-0">
+                          <span>{row.label}</span>
+                          <strong className={row.value < 0 ? 'text-danger' : ''}>
+                            {formatCurrency(row.value, prefs)}
+                          </strong>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </PanelBody>
+              </Panel>
+            </div>
+
+            <div className="col-lg-6 mb-3">
+              <Panel>
+                <PanelHeader noButton><i className="fa fa-chart-pie me-2"></i>Asset allocation</PanelHeader>
+                <PanelBody>
+                  {allocationRows.length === 0 ? (
+                    <div className="text-muted small">No assets yet.</div>
+                  ) : (
+                    <ul className="list-group list-group-flush">
+                      {allocationRows.map(row => (
+                        <li key={row.cls} className="list-group-item px-0">
+                          <div className="d-flex justify-content-between mb-1">
+                            <span>{row.cls}</span>
+                            <span>{formatCurrency(row.value, prefs)} <span className="text-muted small ms-1">{row.pct.toFixed(1)}%</span></span>
+                          </div>
+                          <div className="progress" style={{ height: 4 }}>
+                            <div className="progress-bar bg-primary" style={{ width: `${Math.min(100, row.pct)}%` }} />
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </PanelBody>
+              </Panel>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="col-lg-7 mb-3">
+              <Panel>
+                <PanelHeader noButton><i className="fa fa-credit-card me-2"></i>Liabilities</PanelHeader>
+                <PanelBody>
+                  {liabilities.length === 0 ? (
+                    <div className="text-muted text-center py-3">No liabilities tracked yet.</div>
+                  ) : (
+                    <ul className="list-group list-group-flush">
+                      {liabilities.map(l => (
+                        <li key={l.id} className="list-group-item px-0">
+                          <div className="d-flex align-items-start gap-2">
+                            <i className={`fa ${LIABILITY_KIND_ICON[l.kind]} fa-fw mt-1 text-danger`}></i>
+                            <div className="flex-grow-1">
+                              <div className="d-flex justify-content-between">
+                                <strong>{l.name}</strong>
+                                <span className="text-danger">{formatCurrency(l.currentBalance, prefs)}</span>
+                              </div>
+                              <div className="text-muted small">
+                                {LIABILITY_KIND_LABEL[l.kind]}
+                                {l.interestRate ? ` · ${l.interestRate}% p.a.` : ''}
+                                {l.owner ? ` · ${memberLookup.get(l.owner) || l.owner}` : ' · joint'}
+                              </div>
+                              <div className="small mt-1">
+                                <button className="btn btn-link btn-sm p-0 me-2" onClick={() => beginEditLiability(l)}>Edit</button>
+                                <button className="btn btn-link btn-sm p-0 text-danger" onClick={() => handleDelete(l.id)}>Delete</button>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </PanelBody>
+              </Panel>
+            </div>
+
+            <div className="col-lg-5 mb-3">
+              <Panel>
+                <PanelHeader noButton>
+                  <i className={`fa ${editingId ? 'fa-pen-to-square' : 'fa-plus'} me-2`}></i>
+                  {editingId ? 'Edit liability' : 'Add liability'}
+                </PanelHeader>
+                <PanelBody>
+                  <form onSubmit={handleSubmit}>
+                    <div className="mb-3">
+                      <label className="form-label small text-muted">Name</label>
+                      <input type="text" className="form-control form-control-sm"
+                        value={form.name}
+                        onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+                        placeholder="e.g. ANZ home loan" />
+                    </div>
+                    <div className="row g-2">
+                      <div className="col-6 mb-3">
+                        <label className="form-label small text-muted">Kind</label>
+                        <select className="form-select form-select-sm"
+                          value={form.kind}
+                          onChange={e => setForm(f => ({ ...f, kind: e.target.value as LiabilityKind }))}>
+                          {KIND_OPTIONS.map(k => <option key={k} value={k}>{LIABILITY_KIND_LABEL[k]}</option>)}
+                        </select>
+                      </div>
+                      <div className="col-6 mb-3">
+                        <label className="form-label small text-muted">Owner</label>
+                        <select className="form-select form-select-sm"
+                          value={form.owner}
+                          onChange={e => setForm(f => ({ ...f, owner: e.target.value }))}>
+                          <option value="">Joint / unassigned</option>
+                          {members.map(m => <option key={m.id} value={m.id}>{m.name}</option>)}
+                        </select>
+                      </div>
+                    </div>
+                    <div className="row g-2">
+                      <div className="col-6 mb-3">
+                        <label className="form-label small text-muted">Current balance</label>
+                        <input type="number" min={0} step="0.01" className="form-control form-control-sm"
+                          value={form.currentBalance}
+                          onChange={e => setForm(f => ({ ...f, currentBalance: e.target.value }))} />
+                      </div>
+                      <div className="col-6 mb-3">
+                        <label className="form-label small text-muted">Original amount</label>
+                        <input type="number" min={0} step="0.01" className="form-control form-control-sm"
+                          value={form.originalAmount}
+                          onChange={e => setForm(f => ({ ...f, originalAmount: e.target.value }))} />
+                      </div>
+                    </div>
+                    <div className="row g-2">
+                      <div className="col-6 mb-3">
+                        <label className="form-label small text-muted">Interest rate (% p.a.)</label>
+                        <input type="number" min={0} step="0.01" className="form-control form-control-sm"
+                          value={form.interestRate}
+                          onChange={e => setForm(f => ({ ...f, interestRate: e.target.value }))} />
+                      </div>
+                      <div className="col-6 mb-3">
+                        <label className="form-label small text-muted">Min monthly payment</label>
+                        <input type="number" min={0} step="0.01" className="form-control form-control-sm"
+                          value={form.minMonthlyPayment}
+                          onChange={e => setForm(f => ({ ...f, minMonthlyPayment: e.target.value }))} />
+                      </div>
+                    </div>
+                    {error && <div className="text-danger small mb-2">{error}</div>}
+                    <div className="d-flex gap-2">
+                      <button type="submit" className="btn btn-primary btn-sm" disabled={saving}>
+                        {saving ? <><i className="fa fa-spinner fa-spin me-1"></i>Saving</> : editingId ? 'Save changes' : 'Add liability'}
+                      </button>
+                      {editingId && (
+                        <button type="button" className="btn btn-outline-secondary btn-sm" onClick={resetForm}>Cancel</button>
+                      )}
+                    </div>
+                  </form>
+                </PanelBody>
+              </Panel>
+            </div>
+          </div>
+
+          {history.length > 0 && (
+            <Panel className="mb-3">
+              <PanelHeader noButton><i className="fa fa-chart-line me-2"></i>Trend ({history.length} snapshot{history.length === 1 ? '' : 's'})</PanelHeader>
+              <PanelBody>
+                <ul className="list-group list-group-flush">
+                  {[...history].reverse().slice(0, 12).map(h => (
+                    <li key={h.id} className="list-group-item d-flex justify-content-between px-0 small">
+                      <span>{h.id}</span>
+                      <span>
+                        Net <strong>{formatCurrency(h.netWorth, prefs)}</strong>
+                        <span className="text-muted ms-2">
+                          A {formatCurrency(h.totalAssets, prefs)} · L {formatCurrency(h.totalLiabilities, prefs)}
+                        </span>
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </PanelBody>
+            </Panel>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import { PageFilters, type FilterGroup } from '@/components/page-filters';
 import { currentFinancialYear, maybeEmitEofyReminder } from '@/lib/tax-deadline';
 import { usePreferences } from '@/lib/use-preferences';
 import BudgetsWidget from '@/components/budgets-widget';
+import NetWorthWidget from '@/components/networth-widget';
 
 const CATEGORY_ICONS: Record<string, string> = {
   'Work from Home': 'fa-house-laptop',
@@ -261,6 +262,7 @@ export default function Dashboard() {
         </div>
       </div>
 
+      <NetWorthWidget />
       <BudgetsWidget />
 
       {(tips.length > 0 || tipsLoading) && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,8 @@ import { listExpenses } from '@/lib/expenses-repo';
 import { listInvestments } from '@/lib/investments-repo';
 import { listFamilyMembers } from '@/lib/family-members-repo';
 import { PageFilters, type FilterGroup } from '@/components/page-filters';
-import { maybeEmitEofyReminder } from '@/lib/tax-deadline';
+import { currentFinancialYear, maybeEmitEofyReminder } from '@/lib/tax-deadline';
+import { usePreferences } from '@/lib/use-preferences';
 
 const CATEGORY_ICONS: Record<string, string> = {
   'Work from Home': 'fa-house-laptop',
@@ -49,13 +50,30 @@ const TYPE_COLORS: Record<string, string> = {
 };
 
 export default function Dashboard() {
-  const [financialYear, setFinancialYear] = useState('2025-2026');
+  const { prefs, ready: prefsReady } = usePreferences();
+  const initialFy = prefs.defaults.defaultFinancialYear === 'current'
+    ? currentFinancialYear()
+    : prefs.defaults.defaultFinancialYear;
+  const [financialYear, setFinancialYear] = useState(initialFy);
+  const [fyLockedFromPrefs, setFyLockedFromPrefs] = useState(false);
   const [expenses, setExpenses] = useState<Expense[]>([]);
   const [investments, setInvestments] = useState<Investment[]>([]);
   const [familyMembers, setFamilyMembers] = useState<FamilyMember[]>([]);
   const [loading, setLoading] = useState(true);
   const [tips, setTips] = useState<DashboardTip[]>([]);
   const [tipsLoading, setTipsLoading] = useState(true);
+
+  // When prefs land after the initial render (e.g. logged-in fetch finishes),
+  // sync the FY to the saved default — but only if the user hasn't manually
+  // changed it yet.
+  useEffect(() => {
+    if (!prefsReady || fyLockedFromPrefs) return;
+    const desired = prefs.defaults.defaultFinancialYear === 'current'
+      ? currentFinancialYear()
+      : prefs.defaults.defaultFinancialYear;
+    setFinancialYear(desired);
+    setFyLockedFromPrefs(true);
+  }, [prefsReady, fyLockedFromPrefs, prefs.defaults.defaultFinancialYear]);
 
   const fetchExpenses = useCallback(async () => {
     setExpenses(await listExpenses(financialYear));

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { listFamilyMembers } from '@/lib/family-members-repo';
 import { PageFilters, type FilterGroup } from '@/components/page-filters';
 import { currentFinancialYear, maybeEmitEofyReminder } from '@/lib/tax-deadline';
 import { usePreferences } from '@/lib/use-preferences';
+import BudgetsWidget from '@/components/budgets-widget';
 
 const CATEGORY_ICONS: Record<string, string> = {
   'Work from Home': 'fa-house-laptop',
@@ -259,6 +260,8 @@ export default function Dashboard() {
           </div>
         </div>
       </div>
+
+      <BudgetsWidget />
 
       {(tips.length > 0 || tipsLoading) && (
         <Panel className="mb-3">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,11 +6,15 @@ import ExpensesExclusionSettings from '@/components/expenses-exclusion-settings'
 import CategoryReference from '@/components/category-reference';
 import CashflowReference from '@/components/cashflow-reference';
 import NotificationPreferencesPanel from '@/components/notification-preferences';
+import PreferencesPanel from '@/components/preferences-panel';
 
 export default function SettingsPage() {
   return (
     <>
       <h1 className="page-header">Settings</h1>
+
+      <h2 className="h4 mt-4 mb-3"><i className="fa fa-sliders me-2"></i>Preferences</h2>
+      <PreferencesPanel />
 
       <h2 className="h4 mt-4 mb-3"><i className="fa fa-wallet me-2"></i>Expenses</h2>
       <ExpensesExclusionSettings />

--- a/src/components/auth-gate.tsx
+++ b/src/components/auth-gate.tsx
@@ -4,20 +4,27 @@ import { useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useAuthUser } from '@/lib/use-auth-user';
 import { useGuestMode } from '@/lib/use-guest-mode';
+import { usePreferences } from '@/lib/use-preferences';
 
 export default function AuthGate({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const { user, ready: authReady } = useAuthUser();
   const { guest, ready: guestReady } = useGuestMode();
+  const { prefs, ready: prefsReady } = usePreferences();
   const ready = authReady && guestReady;
   const authenticated = Boolean(user) || guest;
 
   useEffect(() => {
     if (!ready) return;
     if (!authenticated && pathname !== '/login') router.replace('/login');
-    if (authenticated && pathname === '/login') router.replace('/');
-  }, [ready, authenticated, pathname, router]);
+    if (authenticated && pathname === '/login') {
+      // Wait for prefs so we honour the user's chosen homepage on first paint.
+      // Falls back to '/' if prefs aren't ready yet (defaults match anyway).
+      const dest = prefsReady ? prefs.defaults.homepage : '/';
+      router.replace(dest);
+    }
+  }, [ready, authenticated, pathname, router, prefsReady, prefs.defaults.homepage]);
 
   if (!ready) {
     return (

--- a/src/components/budgets-widget.tsx
+++ b/src/components/budgets-widget.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Panel, PanelHeader, PanelBody } from '@/components/panel/panel';
+import { watchBudgets } from '@/lib/budgets-repo';
+import { listExpenses } from '@/lib/expenses-repo';
+import {
+  computeProgress,
+  describeBudget,
+  monthKey,
+} from '@/lib/budgets-calc';
+import type { Budget } from '@/lib/budgets-types';
+import { formatCurrency } from '@/lib/format';
+import { spendingIcon } from '@/lib/spending-categories';
+import { usePreferences } from '@/lib/use-preferences';
+import type { Expense } from '@/lib/types';
+
+const LEVEL_TEXT: Record<'green' | 'amber' | 'red', string> = {
+  green: 'text-success',
+  amber: 'text-warning',
+  red: 'text-danger',
+};
+
+const LEVEL_BG: Record<'green' | 'amber' | 'red', string> = {
+  green: 'bg-success',
+  amber: 'bg-warning',
+  red: 'bg-danger',
+};
+
+export default function BudgetsWidget() {
+  const { prefs } = usePreferences();
+  const [budgets, setBudgets] = useState<Budget[]>([]);
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const off = watchBudgets(setBudgets);
+    listExpenses('all')
+      .then(setExpenses)
+      .catch(() => setExpenses([]))
+      .finally(() => setLoaded(true));
+    return () => off();
+  }, []);
+
+  if (!loaded || budgets.length === 0) return null;
+
+  const month = monthKey(new Date());
+  const top = budgets
+    .map(b => computeProgress(b, expenses, month))
+    .sort((a, b) => b.ratio - a.ratio)
+    .slice(0, 3);
+
+  return (
+    <Panel className="mb-3">
+      <PanelHeader noButton>
+        <div className="d-flex align-items-center">
+          <i className="fa fa-gauge-high me-2"></i>Budgets · top 3
+          <Link href="/budgets" className="ms-auto small text-decoration-none">View all</Link>
+        </div>
+      </PanelHeader>
+      <PanelBody>
+        <div className="row">
+          {top.map(p => (
+            <div key={p.budget.id} className="col-md-4 mb-2 mb-md-0">
+              <div className="d-flex align-items-start gap-2">
+                <i className={`fa ${spendingIcon(p.budget.category)} fa-fw mt-1 ${LEVEL_TEXT[p.level]}`}></i>
+                <div className="flex-grow-1">
+                  <div className="small">{describeBudget(p.budget)}</div>
+                  <div className={`small ${LEVEL_TEXT[p.level]}`}>
+                    {formatCurrency(p.spent, prefs)} / {formatCurrency(p.effectiveCap, prefs)}
+                  </div>
+                  <div className="progress mt-1" style={{ height: 6 }}>
+                    <div
+                      className={`progress-bar ${LEVEL_BG[p.level]}`}
+                      style={{ width: `${Math.min(100, (p.ratio / 1.5) * 100)}%` }}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/src/components/networth-widget.tsx
+++ b/src/components/networth-widget.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Panel, PanelHeader, PanelBody } from '@/components/panel/panel';
+import { listInvestments } from '@/lib/investments-repo';
+import { listLiabilities } from '@/lib/liabilities-repo';
+import { listNetWorthHistory } from '@/lib/networth-history-repo';
+import { computeNetWorth, deltaVs } from '@/lib/networth-calc';
+import { formatCurrency } from '@/lib/format';
+import { usePreferences } from '@/lib/use-preferences';
+import { monthKey } from '@/lib/budgets-calc';
+import type { Liability, NetWorthSnapshot } from '@/lib/networth-types';
+import type { Investment } from '@/lib/types';
+
+export default function NetWorthWidget() {
+  const { prefs } = usePreferences();
+  const [investments, setInvestments] = useState<Investment[]>([]);
+  const [liabilities, setLiabilities] = useState<Liability[]>([]);
+  const [history, setHistory] = useState<NetWorthSnapshot[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    Promise.all([listInvestments(), listLiabilities(), listNetWorthHistory()])
+      .then(([inv, liab, hist]) => { setInvestments(inv); setLiabilities(liab); setHistory(hist); })
+      .catch(() => {})
+      .finally(() => setLoaded(true));
+  }, []);
+
+  if (!loaded) return null;
+  // Render only when there's something meaningful to show.
+  if (investments.length === 0 && liabilities.length === 0) return null;
+
+  const summary = computeNetWorth(investments, liabilities);
+  const month = monthKey(new Date());
+  const [y, m] = month.split('-').map(Number);
+  const prevKey = m === 1 ? `${y - 1}-12` : `${y}-${String(m - 1).padStart(2, '0')}`;
+  const lastMonth = history.find(h => h.id === prevKey);
+  const monthDelta = deltaVs(summary.netWorth, lastMonth?.netWorth);
+  const arrowClass = monthDelta.delta > 0 ? 'text-success' : monthDelta.delta < 0 ? 'text-danger' : 'text-muted';
+  const arrow = monthDelta.delta > 0 ? '▲' : monthDelta.delta < 0 ? '▼' : '–';
+
+  return (
+    <Panel className="mb-3">
+      <PanelHeader noButton>
+        <div className="d-flex align-items-center">
+          <i className="fa fa-scale-balanced me-2"></i>Net worth
+          <Link href="/net-worth" className="ms-auto small text-decoration-none">View detail</Link>
+        </div>
+      </PanelHeader>
+      <PanelBody>
+        <div className="row align-items-center">
+          <div className="col-md-5">
+            <div className="display-6 fw-bold">{formatCurrency(summary.netWorth, prefs)}</div>
+            {lastMonth ? (
+              <small className={arrowClass}>
+                {arrow} {formatCurrency(monthDelta.delta, prefs)} ({monthDelta.pct.toFixed(1)}%) since {prevKey}
+              </small>
+            ) : (
+              <small className="text-muted">Save a snapshot on the Net Worth page to track the trend.</small>
+            )}
+          </div>
+          <div className="col-md-7">
+            <div className="row text-center">
+              <div className="col-6">
+                <div className="text-muted small">Assets</div>
+                <div className="h6 mb-0 text-success">{formatCurrency(summary.totalAssets, prefs)}</div>
+              </div>
+              <div className="col-6">
+                <div className="text-muted small">Liabilities</div>
+                <div className="h6 mb-0 text-danger">{formatCurrency(summary.totalLiabilities, prefs)}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/src/components/preferences-panel.tsx
+++ b/src/components/preferences-panel.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Panel, PanelHeader, PanelBody } from '@/components/panel/panel';
+import { usePreferences } from '@/lib/use-preferences';
+import {
+  DATE_FORMAT_OPTIONS,
+  HOMEPAGE_OPTIONS,
+  NUMBER_LOCALE_OPTIONS,
+  type CurrencyDisplay,
+  type DateFormat,
+  type Density,
+  type Homepage,
+  type NumberLocale,
+} from '@/lib/user-preferences-types';
+import { formatCurrency, formatDate } from '@/lib/format';
+import { currentFinancialYear } from '@/lib/tax-deadline';
+
+type Tab = 'display' | 'defaults' | 'privacy';
+
+export default function PreferencesPanel() {
+  const { prefs, ready, update } = usePreferences();
+  const [tab, setTab] = useState<Tab>('display');
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const persist = async (patch: Parameters<typeof update>[0]) => {
+    setSaving(true);
+    try {
+      await update(patch);
+      setSavedAt(Date.now());
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Build a list of FY options around the current one (current ± 3 years).
+  const fyOptions = useMemo(() => {
+    const fy = currentFinancialYear();
+    const startYear = Number(fy.split('-')[0]);
+    const list: string[] = [];
+    for (let y = startYear - 3; y <= startYear + 1; y++) list.push(`${y}-${y + 1}`);
+    return list.reverse();
+  }, []);
+
+  return (
+    <Panel className="mt-4">
+      <PanelHeader noButton>
+        <i className="fa fa-sliders me-2"></i>Preferences
+      </PanelHeader>
+      <PanelBody>
+        {!ready ? (
+          <div className="text-muted small"><i className="fa fa-spinner fa-spin me-1"></i>Loading…</div>
+        ) : (
+          <>
+            <ul className="nav nav-tabs mb-3">
+              {(['display', 'defaults', 'privacy'] as Tab[]).map(t => (
+                <li className="nav-item" key={t}>
+                  <button
+                    type="button"
+                    className={`nav-link ${tab === t ? 'active' : ''}`}
+                    onClick={() => setTab(t)}
+                  >
+                    {t === 'display' && <><i className="fa fa-eye me-1"></i>Display</>}
+                    {t === 'defaults' && <><i className="fa fa-flag me-1"></i>Defaults</>}
+                    {t === 'privacy' && <><i className="fa fa-shield-halved me-1"></i>Privacy</>}
+                  </button>
+                </li>
+              ))}
+              <li className="nav-item ms-auto d-flex align-items-center pe-2">
+                {saving && <small className="text-muted"><i className="fa fa-spinner fa-spin me-1"></i>Saving</small>}
+                {!saving && savedAt && <small className="text-success"><i className="fa fa-check me-1"></i>Saved</small>}
+              </li>
+            </ul>
+
+            {tab === 'display' && (
+              <div className="row g-3">
+                <div className="col-md-6">
+                  <label className="form-label small text-muted">Date format</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={prefs.display.dateFormat}
+                    onChange={e => persist({ display: { ...prefs.display, dateFormat: e.target.value as DateFormat } })}
+                  >
+                    {DATE_FORMAT_OPTIONS.map(opt => (
+                      <option key={opt.value} value={opt.value}>{opt.label} — {opt.example}</option>
+                    ))}
+                  </select>
+                  <small className="text-muted">Preview: {formatDate(new Date(), prefs)}</small>
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label small text-muted">Number locale</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={prefs.display.numberLocale}
+                    onChange={e => persist({ display: { ...prefs.display, numberLocale: e.target.value as NumberLocale } })}
+                  >
+                    {NUMBER_LOCALE_OPTIONS.map(opt => (
+                      <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label small text-muted">Currency display</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={prefs.display.currencyDisplay}
+                    onChange={e => persist({ display: { ...prefs.display, currencyDisplay: e.target.value as CurrencyDisplay } })}
+                  >
+                    <option value="symbol">Symbol — $1,234</option>
+                    <option value="code">Code — AUD 1,234</option>
+                  </select>
+                  <small className="text-muted">Preview: {formatCurrency(1234.56, prefs, { decimals: 2 })}</small>
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label small text-muted">Density</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={prefs.display.density}
+                    onChange={e => persist({ display: { ...prefs.display, density: e.target.value as Density } })}
+                  >
+                    <option value="comfortable">Comfortable</option>
+                    <option value="compact">Compact</option>
+                  </select>
+                  <small className="text-muted">Compact reduces row spacing in tables.</small>
+                </div>
+              </div>
+            )}
+
+            {tab === 'defaults' && (
+              <div className="row g-3">
+                <div className="col-md-6">
+                  <label className="form-label small text-muted">Homepage</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={prefs.defaults.homepage}
+                    onChange={e => persist({ defaults: { ...prefs.defaults, homepage: e.target.value as Homepage } })}
+                  >
+                    {HOMEPAGE_OPTIONS.map(opt => (
+                      <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                  </select>
+                  <small className="text-muted">Where you land after sign-in.</small>
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label small text-muted">Default financial year</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={prefs.defaults.defaultFinancialYear}
+                    onChange={e => persist({ defaults: { ...prefs.defaults, defaultFinancialYear: e.target.value } })}
+                  >
+                    <option value="current">Current FY ({currentFinancialYear()})</option>
+                    {fyOptions.map(fy => (
+                      <option key={fy} value={fy}>FY {fy}</option>
+                    ))}
+                  </select>
+                  <small className="text-muted">Used by the Dashboard and Tax filters on first load.</small>
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label small text-muted">Default member (expense / investment owner)</label>
+                  <input
+                    type="text"
+                    className="form-control form-control-sm"
+                    placeholder="e.g. Alex"
+                    value={prefs.defaults.defaultMember || ''}
+                    onChange={e => persist({ defaults: { ...prefs.defaults, defaultMember: e.target.value || undefined } })}
+                  />
+                  <small className="text-muted">Pre-fills the Owner field on new entries. Leave blank for none.</small>
+                </div>
+              </div>
+            )}
+
+            {tab === 'privacy' && (
+              <div>
+                <div className="form-check form-switch mb-3">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    id="ai-advice-enabled"
+                    checked={prefs.privacy.aiAdviceEnabled}
+                    onChange={e => persist({ privacy: { ...prefs.privacy, aiAdviceEnabled: e.target.checked } })}
+                  />
+                  <label className="form-check-label" htmlFor="ai-advice-enabled">
+                    <strong>AI features enabled</strong>
+                  </label>
+                  <div className="text-muted small">
+                    Hard kill switch. When off, Dr Finance, dashboard tips, AI categorisation,
+                    and receipt scanning never call Gemini. The panels show a disabled-state
+                    message instead.
+                  </div>
+                </div>
+                <div className="form-check form-switch mb-3">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    id="ai-context-opt-out"
+                    checked={prefs.privacy.aiContextOptOut}
+                    disabled={!prefs.privacy.aiAdviceEnabled}
+                    onChange={e => persist({ privacy: { ...prefs.privacy, aiContextOptOut: e.target.checked } })}
+                  />
+                  <label className="form-check-label" htmlFor="ai-context-opt-out">
+                    <strong>Strip expense descriptions from AI prompts</strong>
+                  </label>
+                  <div className="text-muted small">
+                    Sends only category and amount to Gemini — useful if descriptions could
+                    contain sensitive text. Some advice quality may be reduced.
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/src/config/app-menu.tsx
+++ b/src/config/app-menu.tsx
@@ -6,6 +6,7 @@ const Menu = [
 	{ path: '/expenses', icon: 'fa fa-wallet', title: 'Expenses' },
 	{ path: '/investments', icon: 'fa fa-chart-line', title: 'Investment Portfolio' },
 	{ path: '/budgets', icon: 'fa fa-gauge-high', title: 'Budgets' },
+	{ path: '/net-worth', icon: 'fa fa-scale-balanced', title: 'Net Worth' },
 	{ is_header: true, title: '' },
 	{ path: '/settings', icon: 'fa fa-cog', title: 'Settings' },
 ];

--- a/src/config/app-menu.tsx
+++ b/src/config/app-menu.tsx
@@ -5,6 +5,7 @@ const Menu = [
 	{ path: '/tax', icon: 'fa fa-file-invoice-dollar', title: 'Tax' },
 	{ path: '/expenses', icon: 'fa fa-wallet', title: 'Expenses' },
 	{ path: '/investments', icon: 'fa fa-chart-line', title: 'Investment Portfolio' },
+	{ path: '/budgets', icon: 'fa fa-gauge-high', title: 'Budgets' },
 	{ is_header: true, title: '' },
 	{ path: '/settings', icon: 'fa fa-cog', title: 'Settings' },
 ];

--- a/src/lib/budgets-calc.ts
+++ b/src/lib/budgets-calc.ts
@@ -1,0 +1,129 @@
+import type { Expense } from './types';
+import {
+  DEFAULT_THRESHOLDS,
+  type Budget,
+  type BudgetProgress,
+  type BudgetScope,
+} from './budgets-types';
+
+/** Returns `YYYY-MM` for the calendar month containing `date`. */
+export function monthKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+/** Returns the previous-month key for a `YYYY-MM` value. */
+export function previousMonth(ym: string): string {
+  const [yStr, mStr] = ym.split('-');
+  const y = parseInt(yStr, 10);
+  const m = parseInt(mStr, 10);
+  if (m === 1) return `${y - 1}-12`;
+  return `${y}-${String(m - 1).padStart(2, '0')}`;
+}
+
+/** True if a budget applies to the supplied expense at all. */
+function matches(budget: Budget, expense: Expense): boolean {
+  if (budget.scope === 'overall') return true;
+  if (budget.scope === 'spending-category') {
+    return Boolean(budget.category) && expense.spendingCategory === budget.category;
+  }
+  // spending-sub-category
+  return (
+    Boolean(budget.category) && Boolean(budget.subCategory)
+    && expense.spendingCategory === budget.category
+    && expense.spendingSubCategory === budget.subCategory
+  );
+}
+
+/** Sum spend for `budget` against `expenses` falling in `month` (`YYYY-MM`). */
+export function spendForMonth(budget: Budget, expenses: Expense[], month: string): number {
+  let total = 0;
+  for (const e of expenses) {
+    if (!e?.date || typeof e.amount !== 'number') continue;
+    if (e.date.slice(0, 7) !== month) continue;
+    if (!matches(budget, e)) continue;
+    total += e.amount;
+  }
+  return total;
+}
+
+/**
+ * Surplus that rolls into the current month from the previous one. Capped at
+ * 1× budget.amount so credit doesn't accumulate forever (per issue spec).
+ * Returns 0 when rollover is disabled or the current month is the first.
+ */
+export function rolloverInForMonth(budget: Budget, expenses: Expense[], month: string): number {
+  if (!budget.rolloverUnused) return 0;
+  if (month <= budget.startMonth) return 0;
+  const prev = previousMonth(month);
+  const prevSpend = spendForMonth(budget, expenses, prev);
+  const surplus = budget.amount - prevSpend;
+  if (surplus <= 0) return 0;
+  return Math.min(surplus, budget.amount);
+}
+
+/** Compute progress for a single budget for the supplied month. */
+export function computeProgress(
+  budget: Budget,
+  expenses: Expense[],
+  month: string,
+): BudgetProgress {
+  const spent = spendForMonth(budget, expenses, month);
+  const rolloverIn = rolloverInForMonth(budget, expenses, month);
+  const effectiveCap = Math.max(0.01, budget.amount + rolloverIn);
+  const rawRatio = spent / effectiveCap;
+  const ratio = Math.min(1.5, rawRatio);
+  const level: BudgetProgress['level'] =
+    rawRatio >= 1 ? 'red' : rawRatio >= 0.8 ? 'amber' : 'green';
+  return { budget, month, spent, rolloverIn, effectiveCap, ratio, level };
+}
+
+/**
+ * Returns the highest threshold the budget has crossed this `month` that hasn't
+ * already been alerted on, or null if there's nothing new to fire.
+ *
+ * The dedupe rules:
+ * - When `lastAlertedMonth` differs from `month`, the threshold counter resets
+ *   so each new month gets fresh alerts.
+ * - Within a month, only thresholds STRICTLY GREATER than `lastAlertedThreshold`
+ *   trigger again.
+ */
+export function nextThresholdToAlert(
+  budget: Budget,
+  spent: number,
+  effectiveCap: number,
+  month: string,
+): number | null {
+  const ratio = spent / effectiveCap;
+  const thresholds = budget.alertThresholds?.length
+    ? [...budget.alertThresholds].sort((a, b) => a - b)
+    : [...DEFAULT_THRESHOLDS];
+  const sameMonth = budget.lastAlertedMonth === month;
+  const ceiling = sameMonth ? (budget.lastAlertedThreshold ?? -Infinity) : -Infinity;
+  let next: number | null = null;
+  for (const t of thresholds) {
+    if (ratio >= t && t > ceiling) next = t;
+  }
+  return next;
+}
+
+export function describeBudget(budget: Budget): string {
+  if (budget.scope === 'overall') return 'Overall monthly spending';
+  if (budget.scope === 'spending-sub-category') {
+    return `${budget.category} → ${budget.subCategory}`;
+  }
+  return budget.category ?? 'Uncategorised';
+}
+
+export function thresholdLabel(threshold: number): string {
+  return `${Math.round(threshold * 100)}%`;
+}
+
+export function describeScope(scope: BudgetScope): string {
+  switch (scope) {
+    case 'overall': return 'Overall';
+    case 'spending-category': return 'Category';
+    case 'spending-sub-category': return 'Sub-category';
+  }
+}

--- a/src/lib/budgets-repo.ts
+++ b/src/lib/budgets-repo.ts
@@ -1,0 +1,69 @@
+import {
+  collection,
+  query,
+  orderBy,
+  getDocs,
+  doc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  onSnapshot,
+  type CollectionReference,
+} from 'firebase/firestore';
+import { auth, db } from './firebase';
+import * as guest from './guest-store';
+import type { Budget } from './budgets-types';
+
+function getUserKey(): string {
+  const email = auth?.currentUser?.email;
+  if (!email) throw new Error('Not authenticated');
+  return email;
+}
+
+function budgetsCollection(): CollectionReference {
+  if (!db) throw new Error('Firestore is not initialised');
+  return collection(db, 'users', getUserKey(), 'budgets');
+}
+
+export async function listBudgets(): Promise<Budget[]> {
+  if (guest.isGuest()) return guest.listBudgets();
+  const snap = await getDocs(query(budgetsCollection(), orderBy('amount', 'desc')));
+  return snap.docs.map(d => ({ id: d.id, ...d.data() } as Budget));
+}
+
+export async function addBudget(data: Omit<Budget, 'id'>): Promise<Budget> {
+  if (guest.isGuest()) return guest.addBudget(data);
+  const ref = doc(budgetsCollection());
+  const budget: Budget = { id: ref.id, ...data };
+  await setDoc(ref, budget);
+  return budget;
+}
+
+export async function updateBudget(id: string, patch: Partial<Budget>): Promise<void> {
+  if (guest.isGuest()) { guest.updateBudget(id, patch); return; }
+  if (!db) throw new Error('Firestore is not initialised');
+  const ref = doc(db, 'users', getUserKey(), 'budgets', id);
+  await updateDoc(ref, patch as Record<string, unknown>);
+}
+
+export async function deleteBudget(id: string): Promise<void> {
+  if (guest.isGuest()) { guest.deleteBudget(id); return; }
+  if (!db) throw new Error('Firestore is not initialised');
+  const ref = doc(db, 'users', getUserKey(), 'budgets', id);
+  await deleteDoc(ref);
+}
+
+export function watchBudgets(onChange: (budgets: Budget[]) => void): () => void {
+  if (guest.isGuest()) {
+    onChange(guest.listBudgets());
+    return () => {};
+  }
+  try {
+    const q = query(budgetsCollection(), orderBy('amount', 'desc'));
+    return onSnapshot(q, snap => {
+      onChange(snap.docs.map(d => ({ id: d.id, ...d.data() } as Budget)));
+    }, () => onChange([]));
+  } catch {
+    return () => {};
+  }
+}

--- a/src/lib/budgets-types.ts
+++ b/src/lib/budgets-types.ts
@@ -1,0 +1,40 @@
+export type BudgetScope = 'overall' | 'spending-category' | 'spending-sub-category';
+
+export interface Budget {
+  id: string;
+  scope: BudgetScope;
+  /** Required for `spending-category` and `spending-sub-category`. */
+  category?: string;
+  /** Required for `spending-sub-category`. */
+  subCategory?: string;
+  /** Monthly cap, in dollars. */
+  amount: number;
+  period: 'monthly';
+  /** First month this budget is active, `YYYY-MM`. */
+  startMonth: string;
+  rolloverUnused: boolean;
+  /** Fractions of `amount` at which to alert, e.g. [0.8, 1.0, 1.2]. */
+  alertThresholds: number[];
+  /** Set by the cron when an alert fires — used to dedupe. `YYYY-MM`. */
+  lastAlertedMonth?: string;
+  /** Highest threshold (fraction) already alerted on for `lastAlertedMonth`. */
+  lastAlertedThreshold?: number;
+}
+
+export const DEFAULT_THRESHOLDS = [0.8, 1.0, 1.2] as const;
+
+export interface BudgetProgress {
+  budget: Budget;
+  /** Calendar month under evaluation, `YYYY-MM`. */
+  month: string;
+  /** Plain MTD spend for the budget's scope. */
+  spent: number;
+  /** Carried-forward surplus from the previous month (0 if rollover disabled). */
+  rolloverIn: number;
+  /** Effective cap = budget.amount + rolloverIn. */
+  effectiveCap: number;
+  /** spent / effectiveCap, capped at 1.5 for the visual bar. */
+  ratio: number;
+  /** UI severity bucket. */
+  level: 'green' | 'amber' | 'red';
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,99 @@
+import {
+  DEFAULT_PREFERENCES,
+  type CurrencyDisplay,
+  type DateFormat,
+  type NumberLocale,
+  type UserPreferences,
+} from './user-preferences-types';
+
+const MONTH_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function parseDate(input: Date | string | number | null | undefined): Date | null {
+  if (input == null) return null;
+  if (input instanceof Date) return Number.isFinite(input.getTime()) ? input : null;
+  if (typeof input === 'number') {
+    const d = new Date(input);
+    return Number.isFinite(d.getTime()) ? d : null;
+  }
+  // string — accept YYYY-MM-DD without time so it doesn't shift to UTC midnight
+  if (/^\d{4}-\d{2}-\d{2}$/.test(input)) {
+    const [y, m, d] = input.split('-').map(Number);
+    return new Date(y, m - 1, d);
+  }
+  const d = new Date(input);
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+export function formatDate(
+  input: Date | string | number | null | undefined,
+  prefs: Pick<UserPreferences, 'display'> = DEFAULT_PREFERENCES,
+): string {
+  const d = parseDate(input);
+  if (!d) return '';
+  return formatWithStyle(d, prefs.display.dateFormat);
+}
+
+function formatWithStyle(d: Date, style: DateFormat): string {
+  const day = d.getDate();
+  const month = d.getMonth() + 1;
+  const year = d.getFullYear();
+  switch (style) {
+    case 'YYYY-MM-DD':
+      return `${year}-${pad(month)}-${pad(day)}`;
+    case 'D MMM YYYY':
+      return `${day} ${MONTH_SHORT[d.getMonth()]} ${year}`;
+    case 'DD/MM/YYYY':
+    default:
+      return `${pad(day)}/${pad(month)}/${year}`;
+  }
+}
+
+export interface CurrencyOptions {
+  /** Default 0 — pass 2 for cents. */
+  decimals?: number;
+  /** Override the per-pref currency display. */
+  display?: CurrencyDisplay;
+}
+
+const CURRENCY_SYMBOL: Record<NumberLocale, string> = {
+  'en-AU': '$',
+  'en-US': '$',
+  'en-GB': '£',
+};
+
+export function formatCurrency(
+  amount: number | null | undefined,
+  prefs: Pick<UserPreferences, 'display'> = DEFAULT_PREFERENCES,
+  opts: CurrencyOptions = {},
+): string {
+  const value = typeof amount === 'number' && Number.isFinite(amount) ? amount : 0;
+  const decimals = opts.decimals ?? 0;
+  const locale = prefs.display.numberLocale;
+  const display = opts.display ?? prefs.display.currencyDisplay;
+  const formatted = Math.abs(value).toLocaleString(locale, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+  const sign = value < 0 ? '-' : '';
+  if (display === 'code') {
+    return `${sign}AUD ${formatted}`;
+  }
+  return `${sign}${CURRENCY_SYMBOL[locale]}${formatted}`;
+}
+
+/** Plain number formatter (no currency) — uses the pref locale. */
+export function formatNumber(
+  amount: number | null | undefined,
+  prefs: Pick<UserPreferences, 'display'> = DEFAULT_PREFERENCES,
+  decimals = 0,
+): string {
+  const value = typeof amount === 'number' && Number.isFinite(amount) ? amount : 0;
+  return value.toLocaleString(prefs.display.numberLocale, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}

--- a/src/lib/functions-client.ts
+++ b/src/lib/functions-client.ts
@@ -3,12 +3,24 @@ import { functions } from './firebase';
 import type { Expense } from './types';
 import * as guest from './guest-store';
 import { GUEST_DASHBOARD_TIPS, mockTaxAdviceStream, mockInvestmentsAdviceStream, mockExpensesAdviceStream } from './guest-mocks';
+import { isAiAdviceAllowed, isAiContextOptOut } from './preferences-cache';
 
 type ChatMessage = { role: 'user' | 'model'; text: string };
 
 function assertFunctions() {
   if (!functions) throw new Error('Firebase Functions is not initialised');
   return functions;
+}
+
+export class AiDisabledError extends Error {
+  constructor() {
+    super('AI features are disabled in Settings → Privacy.');
+    this.name = 'AiDisabledError';
+  }
+}
+
+function assertAiAllowed() {
+  if (!isAiAdviceAllowed()) throw new AiDisabledError();
 }
 
 export async function adviceChatGet<T = ChatMessage>(type: 'tax' | 'investments' | 'expenses' | 'custom-spending-categories'): Promise<T[]> {
@@ -37,9 +49,10 @@ export interface DashboardTip {
 }
 
 export async function fetchDashboardTips(): Promise<DashboardTip[]> {
+  if (!isAiAdviceAllowed()) return [];
   if (guest.isGuest()) return GUEST_DASHBOARD_TIPS;
-  const fn = httpsCallable<unknown, { tips: DashboardTip[] }>(assertFunctions(), 'dashboardTips');
-  const res = await fn({});
+  const fn = httpsCallable<{ aiContextOptOut?: boolean }, { tips: DashboardTip[] }>(assertFunctions(), 'dashboardTips');
+  const res = await fn({ aiContextOptOut: isAiContextOptOut() });
   return res.data.tips ?? [];
 }
 
@@ -49,23 +62,26 @@ export interface AdviceStreamHandle {
 }
 
 export async function streamTaxAdvice(payload: { financialYear?: string; history?: ChatMessage[]; followUp?: string }): Promise<AdviceStreamHandle> {
+  assertAiAllowed();
   if (guest.isGuest()) return mockTaxAdviceStream();
-  const fn = httpsCallable<typeof payload, { text: string }, string>(assertFunctions(), 'taxAdvice');
-  const result = await fn.stream(payload);
+  const fn = httpsCallable<typeof payload & { aiContextOptOut?: boolean }, { text: string }, string>(assertFunctions(), 'taxAdvice');
+  const result = await fn.stream({ ...payload, aiContextOptOut: isAiContextOptOut() });
   return { stream: result.stream, final: result.data.then(d => d.text) };
 }
 
 export async function streamInvestmentsAdvice(payload: { history?: ChatMessage[]; followUp?: string }): Promise<AdviceStreamHandle> {
+  assertAiAllowed();
   if (guest.isGuest()) return mockInvestmentsAdviceStream();
-  const fn = httpsCallable<typeof payload, { text: string }, string>(assertFunctions(), 'investmentsAdvice');
-  const result = await fn.stream(payload);
+  const fn = httpsCallable<typeof payload & { aiContextOptOut?: boolean }, { text: string }, string>(assertFunctions(), 'investmentsAdvice');
+  const result = await fn.stream({ ...payload, aiContextOptOut: isAiContextOptOut() });
   return { stream: result.stream, final: result.data.then(d => d.text) };
 }
 
 export async function streamExpensesAdvice(payload: { history?: ChatMessage[]; followUp?: string }): Promise<AdviceStreamHandle> {
+  assertAiAllowed();
   if (guest.isGuest()) return mockExpensesAdviceStream();
-  const fn = httpsCallable<typeof payload, { text: string }, string>(assertFunctions(), 'expensesAdvice');
-  const result = await fn.stream(payload);
+  const fn = httpsCallable<typeof payload & { aiContextOptOut?: boolean }, { text: string }, string>(assertFunctions(), 'expensesAdvice');
+  const result = await fn.stream({ ...payload, aiContextOptOut: isAiContextOptOut() });
   return { stream: result.stream, final: result.data.then(d => d.text) };
 }
 
@@ -183,9 +199,10 @@ export async function cashflowImportSave(rows: Omit<Income, 'id'>[]): Promise<Ca
 }
 
 export async function reanalyseExpenses(payload: { financialYear?: string; type?: 'tax' | 'spending' | 'sub-category' }): Promise<{ updated: number; total: number }> {
+  assertAiAllowed();
   if (guest.isGuest()) return { updated: 0, total: 0 };
-  const fn = httpsCallable<typeof payload, { updated: number; total: number }>(assertFunctions(), 'expensesReanalyse');
-  const res = await fn(payload);
+  const fn = httpsCallable<typeof payload & { aiContextOptOut?: boolean }, { updated: number; total: number }>(assertFunctions(), 'expensesReanalyse');
+  const res = await fn({ ...payload, aiContextOptOut: isAiContextOptOut() });
   return res.data;
 }
 
@@ -202,6 +219,7 @@ export interface ReceiptScanResult {
 }
 
 export async function scanReceipt(imageBase64: string, mimeType: string): Promise<ReceiptScanResult> {
+  assertAiAllowed();
   if (guest.isGuest()) {
     throw new Error('Receipt scanning is disabled in Guest mode — sign in with Google to use Dr Finance Vision.');
   }

--- a/src/lib/guest-store.ts
+++ b/src/lib/guest-store.ts
@@ -1,6 +1,7 @@
 import { GUEST_SEED } from './guest-seed';
 import type { Expense, FamilyMember, Investment, IncomeSource } from './types';
 import type { Notification, NotificationKind, NotificationPreferences } from './notification-types';
+import type { UserPreferences } from './user-preferences-types';
 
 const FLAG_KEY = 'fd_guest';
 
@@ -49,6 +50,7 @@ interface GuestState {
   incomeSources?: IncomeSource[];
   notifications?: Notification[];
   notificationPreferences?: NotificationPreferences;
+  userPreferences?: UserPreferences;
 }
 
 function clone<T>(v: T): T {
@@ -296,4 +298,14 @@ export function getNotificationPreferences(): NotificationPreferences | undefine
 
 export function setNotificationPreferences(prefs: NotificationPreferences) {
   state.notificationPreferences = prefs;
+}
+
+// User preferences --------------------------------------------------------
+
+export function getUserPreferences(): UserPreferences | undefined {
+  return state.userPreferences;
+}
+
+export function setUserPreferences(prefs: UserPreferences) {
+  state.userPreferences = prefs;
 }

--- a/src/lib/guest-store.ts
+++ b/src/lib/guest-store.ts
@@ -3,6 +3,7 @@ import type { Expense, FamilyMember, Investment, IncomeSource } from './types';
 import type { Notification, NotificationKind, NotificationPreferences } from './notification-types';
 import type { UserPreferences } from './user-preferences-types';
 import type { Budget } from './budgets-types';
+import type { Liability, NetWorthSnapshot } from './networth-types';
 
 const FLAG_KEY = 'fd_guest';
 
@@ -53,6 +54,8 @@ interface GuestState {
   notificationPreferences?: NotificationPreferences;
   userPreferences?: UserPreferences;
   budgets?: Budget[];
+  liabilities?: Liability[];
+  netWorthHistory?: NetWorthSnapshot[];
 }
 
 function clone<T>(v: T): T {
@@ -330,4 +333,40 @@ export function updateBudget(id: string, patch: Partial<Budget>) {
 
 export function deleteBudget(id: string) {
   state.budgets = (state.budgets || []).filter(b => b.id !== id);
+}
+
+// Liabilities -------------------------------------------------------------
+
+export function listLiabilities(): Liability[] {
+  return [...(state.liabilities || [])];
+}
+
+export function addLiability(data: Omit<Liability, 'id'>): Liability {
+  const liability: Liability = { id: rid('l'), ...data };
+  state.liabilities = [...(state.liabilities || []), liability];
+  return liability;
+}
+
+export function updateLiability(id: string, patch: Partial<Liability>) {
+  state.liabilities = (state.liabilities || []).map(l => l.id === id ? { ...l, ...patch } : l);
+}
+
+export function deleteLiability(id: string) {
+  state.liabilities = (state.liabilities || []).filter(l => l.id !== id);
+}
+
+// Net worth history -------------------------------------------------------
+
+export function listNetWorthHistory(): NetWorthSnapshot[] {
+  return [...(state.netWorthHistory || [])].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function saveNetWorthSnapshot(snapshot: NetWorthSnapshot) {
+  const list = state.netWorthHistory || [];
+  const idx = list.findIndex(s => s.id === snapshot.id);
+  if (idx >= 0) {
+    state.netWorthHistory = list.map((s, i) => i === idx ? snapshot : s);
+  } else {
+    state.netWorthHistory = [...list, snapshot];
+  }
 }

--- a/src/lib/guest-store.ts
+++ b/src/lib/guest-store.ts
@@ -2,6 +2,7 @@ import { GUEST_SEED } from './guest-seed';
 import type { Expense, FamilyMember, Investment, IncomeSource } from './types';
 import type { Notification, NotificationKind, NotificationPreferences } from './notification-types';
 import type { UserPreferences } from './user-preferences-types';
+import type { Budget } from './budgets-types';
 
 const FLAG_KEY = 'fd_guest';
 
@@ -51,6 +52,7 @@ interface GuestState {
   notifications?: Notification[];
   notificationPreferences?: NotificationPreferences;
   userPreferences?: UserPreferences;
+  budgets?: Budget[];
 }
 
 function clone<T>(v: T): T {
@@ -308,4 +310,24 @@ export function getUserPreferences(): UserPreferences | undefined {
 
 export function setUserPreferences(prefs: UserPreferences) {
   state.userPreferences = prefs;
+}
+
+// Budgets -----------------------------------------------------------------
+
+export function listBudgets(): Budget[] {
+  return [...(state.budgets || [])];
+}
+
+export function addBudget(data: Omit<Budget, 'id'>): Budget {
+  const budget: Budget = { id: rid('b'), ...data };
+  state.budgets = [...(state.budgets || []), budget];
+  return budget;
+}
+
+export function updateBudget(id: string, patch: Partial<Budget>) {
+  state.budgets = (state.budgets || []).map(b => b.id === id ? { ...b, ...patch } : b);
+}
+
+export function deleteBudget(id: string) {
+  state.budgets = (state.budgets || []).filter(b => b.id !== id);
 }

--- a/src/lib/liabilities-repo.ts
+++ b/src/lib/liabilities-repo.ts
@@ -1,0 +1,57 @@
+import {
+  collection,
+  query,
+  orderBy,
+  getDocs,
+  doc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  type CollectionReference,
+} from 'firebase/firestore';
+import { auth, db } from './firebase';
+import * as guest from './guest-store';
+import type { Liability } from './networth-types';
+
+function getUserKey(): string {
+  const email = auth?.currentUser?.email;
+  if (!email) throw new Error('Not authenticated');
+  return email;
+}
+
+function liabilitiesCollection(): CollectionReference {
+  if (!db) throw new Error('Firestore is not initialised');
+  return collection(db, 'users', getUserKey(), 'liabilities');
+}
+
+export async function listLiabilities(): Promise<Liability[]> {
+  if (guest.isGuest()) return guest.listLiabilities();
+  try {
+    const snap = await getDocs(query(liabilitiesCollection(), orderBy('currentBalance', 'desc')));
+    return snap.docs.map(d => ({ id: d.id, ...d.data() } as Liability));
+  } catch {
+    return [];
+  }
+}
+
+export async function addLiability(data: Omit<Liability, 'id'>): Promise<Liability> {
+  if (guest.isGuest()) return guest.addLiability(data);
+  const ref = doc(liabilitiesCollection());
+  const liability: Liability = { id: ref.id, ...data };
+  await setDoc(ref, liability);
+  return liability;
+}
+
+export async function updateLiability(id: string, patch: Partial<Liability>): Promise<void> {
+  if (guest.isGuest()) { guest.updateLiability(id, patch); return; }
+  if (!db) throw new Error('Firestore is not initialised');
+  const ref = doc(db, 'users', getUserKey(), 'liabilities', id);
+  await updateDoc(ref, patch as Record<string, unknown>);
+}
+
+export async function deleteLiability(id: string): Promise<void> {
+  if (guest.isGuest()) { guest.deleteLiability(id); return; }
+  if (!db) throw new Error('Firestore is not initialised');
+  const ref = doc(db, 'users', getUserKey(), 'liabilities', id);
+  await deleteDoc(ref);
+}

--- a/src/lib/networth-calc.ts
+++ b/src/lib/networth-calc.ts
@@ -1,0 +1,109 @@
+import type { Investment } from './types';
+import type { Liability, LiabilityKind, NetWorthSnapshot } from './networth-types';
+
+const JOINT_KEY = '__joint';
+
+export interface NetWorthOptions {
+  /** Drop superannuation values from totals when true. */
+  excludeSuper?: boolean;
+}
+
+export interface NetWorthSummary {
+  totalAssets: number;
+  totalLiabilities: number;
+  netWorth: number;
+  assetsByClass: Record<string, number>;
+  liabilitiesByKind: Partial<Record<LiabilityKind, number>>;
+  netWorthByMember: Record<string, number>;
+  superValue: number;
+}
+
+function isSuper(inv: Investment): boolean {
+  return inv.type === 'Superannuation';
+}
+
+/**
+ * Compute the household net-worth roll-up. Per-member values split joint
+ * liabilities across `__joint`. Caller decides if super counts via `opts`.
+ */
+export function computeNetWorth(
+  investments: Investment[],
+  liabilities: Liability[],
+  opts: NetWorthOptions = {},
+): NetWorthSummary {
+  const assetsByClass: Record<string, number> = {};
+  const liabilitiesByKind: Partial<Record<LiabilityKind, number>> = {};
+  const netWorthByMember: Record<string, number> = {};
+
+  let totalAssets = 0;
+  let totalLiabilities = 0;
+  let superValue = 0;
+
+  for (const inv of investments) {
+    if (typeof inv.currentValue !== 'number' || !Number.isFinite(inv.currentValue)) continue;
+    if (isSuper(inv)) {
+      superValue += inv.currentValue;
+      if (opts.excludeSuper) continue;
+    }
+    totalAssets += inv.currentValue;
+    assetsByClass[inv.type] = (assetsByClass[inv.type] || 0) + inv.currentValue;
+
+    const ownerKey = inv.owner || JOINT_KEY;
+    netWorthByMember[ownerKey] = (netWorthByMember[ownerKey] || 0) + inv.currentValue;
+  }
+
+  for (const liab of liabilities) {
+    if (typeof liab.currentBalance !== 'number' || !Number.isFinite(liab.currentBalance)) continue;
+    totalLiabilities += liab.currentBalance;
+    liabilitiesByKind[liab.kind] = (liabilitiesByKind[liab.kind] || 0) + liab.currentBalance;
+    const ownerKey = liab.owner || JOINT_KEY;
+    netWorthByMember[ownerKey] = (netWorthByMember[ownerKey] || 0) - liab.currentBalance;
+  }
+
+  return {
+    totalAssets,
+    totalLiabilities,
+    netWorth: totalAssets - totalLiabilities,
+    assetsByClass,
+    liabilitiesByKind,
+    netWorthByMember,
+    superValue,
+  };
+}
+
+export interface DeltaSummary {
+  current: number;
+  previous: number;
+  delta: number;
+  pct: number;
+}
+
+/**
+ * Compare two snapshots; falls back to zero when there's no previous snapshot.
+ * `pct` is null-safe — returns 0 when previous is 0 to avoid Infinity.
+ */
+export function deltaVs(current: number, previous: number | null | undefined): DeltaSummary {
+  const prev = typeof previous === 'number' && Number.isFinite(previous) ? previous : 0;
+  const delta = current - prev;
+  const pct = prev === 0 ? 0 : (delta / Math.abs(prev)) * 100;
+  return { current, previous: prev, delta, pct };
+}
+
+/**
+ * Derive the snapshot doc shape from a live summary plus a `YYYY-MM` key.
+ */
+export function snapshotFromSummary(month: string, summary: NetWorthSummary): NetWorthSnapshot {
+  return {
+    id: month,
+    capturedAt: new Date().toISOString(),
+    totalAssets: summary.totalAssets,
+    totalLiabilities: summary.totalLiabilities,
+    netWorth: summary.netWorth,
+    assetsByClass: { ...summary.assetsByClass },
+    liabilitiesByKind: { ...summary.liabilitiesByKind },
+    netWorthByMember: { ...summary.netWorthByMember },
+    superValue: summary.superValue,
+  };
+}
+
+export const NET_WORTH_JOINT_KEY = JOINT_KEY;

--- a/src/lib/networth-history-repo.ts
+++ b/src/lib/networth-history-repo.ts
@@ -1,0 +1,40 @@
+import {
+  collection,
+  query,
+  orderBy,
+  getDocs,
+  doc,
+  setDoc,
+  type CollectionReference,
+} from 'firebase/firestore';
+import { auth, db } from './firebase';
+import * as guest from './guest-store';
+import type { NetWorthSnapshot } from './networth-types';
+
+function getUserKey(): string {
+  const email = auth?.currentUser?.email;
+  if (!email) throw new Error('Not authenticated');
+  return email;
+}
+
+function historyCollection(): CollectionReference {
+  if (!db) throw new Error('Firestore is not initialised');
+  return collection(db, 'users', getUserKey(), 'networth-history');
+}
+
+export async function listNetWorthHistory(): Promise<NetWorthSnapshot[]> {
+  if (guest.isGuest()) return guest.listNetWorthHistory();
+  try {
+    const snap = await getDocs(query(historyCollection(), orderBy('id', 'asc')));
+    return snap.docs.map(d => ({ id: d.id, ...d.data() } as NetWorthSnapshot));
+  } catch {
+    return [];
+  }
+}
+
+export async function saveNetWorthSnapshot(snapshot: NetWorthSnapshot): Promise<void> {
+  if (guest.isGuest()) { guest.saveNetWorthSnapshot(snapshot); return; }
+  if (!db) throw new Error('Firestore is not initialised');
+  const ref = doc(db, 'users', getUserKey(), 'networth-history', snapshot.id);
+  await setDoc(ref, snapshot, { merge: true });
+}

--- a/src/lib/networth-types.ts
+++ b/src/lib/networth-types.ts
@@ -1,0 +1,56 @@
+export type LiabilityKind =
+  | 'mortgage'
+  | 'personal-loan'
+  | 'car-loan'
+  | 'student-loan'
+  | 'credit-card'
+  | 'other';
+
+export interface Liability {
+  id: string;
+  name: string;
+  kind: LiabilityKind;
+  /** Family member id; null/undefined means a joint liability. */
+  owner?: string;
+  currentBalance: number;
+  originalAmount: number;
+  interestRate?: number;
+  minMonthlyPayment?: number;
+  /** Investment id this is collateralised against (e.g. mortgage → property). */
+  linkedAssetId?: string;
+}
+
+/** A single point on the net-worth trend line, persisted per month. */
+export interface NetWorthSnapshot {
+  /** Doc id is the YYYY-MM key. */
+  id: string;
+  capturedAt: string; // ISO 8601
+  totalAssets: number;
+  totalLiabilities: number;
+  netWorth: number;
+  /** sum of currentValue per investment.type, e.g. { 'Property': 850000, ... } */
+  assetsByClass: Record<string, number>;
+  /** sum of currentBalance per liability.kind */
+  liabilitiesByKind: Partial<Record<LiabilityKind, number>>;
+  /** Per-owner breakdown. Key is family-member id, plus '__joint' for un-owned. */
+  netWorthByMember: Record<string, number>;
+  superValue: number;
+}
+
+export const LIABILITY_KIND_LABEL: Record<LiabilityKind, string> = {
+  'mortgage': 'Mortgage',
+  'personal-loan': 'Personal loan',
+  'car-loan': 'Car loan',
+  'student-loan': 'Student loan',
+  'credit-card': 'Credit card',
+  'other': 'Other',
+};
+
+export const LIABILITY_KIND_ICON: Record<LiabilityKind, string> = {
+  'mortgage': 'fa-house',
+  'personal-loan': 'fa-hand-holding-dollar',
+  'car-loan': 'fa-car',
+  'student-loan': 'fa-graduation-cap',
+  'credit-card': 'fa-credit-card',
+  'other': 'fa-circle-question',
+};

--- a/src/lib/preferences-cache.ts
+++ b/src/lib/preferences-cache.ts
@@ -1,0 +1,22 @@
+import { DEFAULT_PREFERENCES, type UserPreferences } from './user-preferences-types';
+
+// Synchronous cache so non-React callers (functions-client, dispatch sites)
+// can read user preferences without prop-drilling. The React provider keeps
+// it fresh by calling `setCachedPreferences` whenever prefs load or change.
+let cached: UserPreferences = { ...DEFAULT_PREFERENCES };
+
+export function getCachedPreferences(): UserPreferences {
+  return cached;
+}
+
+export function setCachedPreferences(prefs: UserPreferences): void {
+  cached = prefs;
+}
+
+export function isAiAdviceAllowed(): boolean {
+  return cached.privacy.aiAdviceEnabled !== false;
+}
+
+export function isAiContextOptOut(): boolean {
+  return cached.privacy.aiContextOptOut === true;
+}

--- a/src/lib/spending-categories.ts
+++ b/src/lib/spending-categories.ts
@@ -1,0 +1,59 @@
+export const SPENDING_ICONS: Record<string, string> = {
+  'Bakery': 'fa-bread-slice',
+  'Cafe': 'fa-mug-hot',
+  'Car': 'fa-car-side',
+  'Dining & Takeaway': 'fa-utensils',
+  'Education': 'fa-graduation-cap',
+  'Entertainment': 'fa-film',
+  'Financial & Banking': 'fa-university',
+  'Gifts & Donations': 'fa-gift',
+  'Groceries': 'fa-cart-shopping',
+  'Healthcare': 'fa-heart-pulse',
+  'Home & Garden': 'fa-house',
+  'Insurance': 'fa-shield',
+  'Kids Entertainment': 'fa-child',
+  'Personal Care': 'fa-spa',
+  'Personal Project': 'fa-lightbulb',
+  'Shopping': 'fa-bag-shopping',
+  'Subscriptions': 'fa-repeat',
+  'Transport': 'fa-car',
+  'Travel & Holidays': 'fa-plane',
+  'Utilities & Bills': 'fa-bolt',
+  'Other': 'fa-ellipsis',
+};
+
+export const SPENDING_COLORS: Record<string, string> = {
+  'Bakery': '#d4a373',
+  'Cafe': '#8d6e63',
+  'Car': '#455a64',
+  'Dining & Takeaway': '#fd7e14',
+  'Education': '#0dcaf0',
+  'Entertainment': '#6f42c1',
+  'Financial & Banking': '#607d8b',
+  'Gifts & Donations': '#e91e63',
+  'Groceries': '#20c997',
+  'Healthcare': '#dc3545',
+  'Home & Garden': '#795548',
+  'Insurance': '#198754',
+  'Kids Entertainment': '#4caf50',
+  'Personal Care': '#ff69b4',
+  'Personal Project': '#ff9800',
+  'Shopping': '#e83e8c',
+  'Subscriptions': '#6610f2',
+  'Transport': '#0d6efd',
+  'Travel & Holidays': '#17a2b8',
+  'Utilities & Bills': '#ffc107',
+  'Other': '#6c757d',
+};
+
+export const DEFAULT_SPENDING_CATEGORIES = Object.keys(SPENDING_ICONS);
+
+export function spendingIcon(category: string | undefined | null): string {
+  if (!category) return 'fa-ellipsis';
+  return SPENDING_ICONS[category] || 'fa-ellipsis';
+}
+
+export function spendingColor(category: string | undefined | null): string {
+  if (!category) return '#6c757d';
+  return SPENDING_COLORS[category] || '#6c757d';
+}

--- a/src/lib/use-preferences.tsx
+++ b/src/lib/use-preferences.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { getUserPreferences, saveUserPreferences } from './user-preferences-repo';
+import {
+  DEFAULT_PREFERENCES,
+  type UserPreferences,
+} from './user-preferences-types';
+import { useAuthUser } from './use-auth-user';
+import { useGuestMode } from './use-guest-mode';
+import { setCachedPreferences } from './preferences-cache';
+
+interface PreferencesContextValue {
+  prefs: UserPreferences;
+  ready: boolean;
+  update: (patch: Partial<UserPreferences>) => Promise<void>;
+}
+
+const PreferencesContext = createContext<PreferencesContextValue | undefined>(undefined);
+
+// Re-export the synchronous helpers so callers don't have to know the cache is
+// in a separate module. The React-free entry point lives in preferences-cache.
+export { getCachedPreferences, isAiAdviceAllowed, isAiContextOptOut } from './preferences-cache';
+
+export function PreferencesProvider({ children }: { children: ReactNode }) {
+  const { user, ready: authReady } = useAuthUser();
+  const { guest, ready: guestReady } = useGuestMode();
+  const [prefs, setPrefs] = useState<UserPreferences>(DEFAULT_PREFERENCES);
+  const [ready, setReady] = useState(false);
+
+  const reload = useCallback(async () => {
+    try {
+      const next = await getUserPreferences();
+      setCachedPreferences(next);
+      setPrefs(next);
+    } catch {
+      setCachedPreferences({ ...DEFAULT_PREFERENCES });
+      setPrefs({ ...DEFAULT_PREFERENCES });
+    } finally {
+      setReady(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!authReady || !guestReady) return;
+    if (!user && !guest) {
+      // Logged out — defaults only, no fetch.
+      setCachedPreferences({ ...DEFAULT_PREFERENCES });
+      setPrefs({ ...DEFAULT_PREFERENCES });
+      setReady(true);
+      return;
+    }
+    reload();
+  }, [authReady, guestReady, user, guest, reload]);
+
+  // Density class on the body element. Toggled here so it survives navigation.
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const cls = 'density-compact';
+    if (prefs.display.density === 'compact') document.body.classList.add(cls);
+    else document.body.classList.remove(cls);
+    return () => { document.body.classList.remove(cls); };
+  }, [prefs.display.density]);
+
+  const update = useCallback(async (patch: Partial<UserPreferences>) => {
+    const merged: UserPreferences = {
+      display: { ...prefs.display, ...(patch.display || {}) },
+      defaults: { ...prefs.defaults, ...(patch.defaults || {}) },
+      privacy: { ...prefs.privacy, ...(patch.privacy || {}) },
+      onboardedAt: patch.onboardedAt ?? prefs.onboardedAt,
+    };
+    setCachedPreferences(merged);
+    setPrefs(merged);
+    try {
+      await saveUserPreferences(merged);
+    } catch {
+      // Persistence failed but local state already reflects the change so the
+      // user sees their toggle take effect; next mount will re-read truth.
+    }
+  }, [prefs]);
+
+  const value = useMemo(() => ({ prefs, ready, update }), [prefs, ready, update]);
+
+  return <PreferencesContext.Provider value={value}>{children}</PreferencesContext.Provider>;
+}
+
+/**
+ * Returns the active preferences. When called outside a `PreferencesProvider`
+ * (e.g. in unit tests that render a single page), falls back to the defaults
+ * with a no-op `update` so callers don't need to mount the provider.
+ */
+export function usePreferences(): PreferencesContextValue {
+  const ctx = useContext(PreferencesContext);
+  if (ctx) return ctx;
+  return {
+    prefs: { ...DEFAULT_PREFERENCES },
+    ready: true,
+    update: async () => {},
+  };
+}

--- a/src/lib/user-preferences-repo.ts
+++ b/src/lib/user-preferences-repo.ts
@@ -1,0 +1,34 @@
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { auth, db } from './firebase';
+import * as guest from './guest-store';
+import {
+  DEFAULT_PREFERENCES,
+  withDefaults,
+  type UserPreferences,
+} from './user-preferences-types';
+
+function getUserKey(): string {
+  const email = auth?.currentUser?.email;
+  if (!email) throw new Error('Not authenticated');
+  return email;
+}
+
+function profileRef() {
+  if (!db) throw new Error('Firestore is not initialised');
+  return doc(db, 'users', getUserKey(), 'meta', 'profile');
+}
+
+export async function getUserPreferences(): Promise<UserPreferences> {
+  if (guest.isGuest()) return withDefaults(guest.getUserPreferences());
+  try {
+    const snap = await getDoc(profileRef());
+    return withDefaults(snap.exists() ? (snap.data() as Partial<UserPreferences>) : {});
+  } catch {
+    return { ...DEFAULT_PREFERENCES };
+  }
+}
+
+export async function saveUserPreferences(prefs: UserPreferences): Promise<void> {
+  if (guest.isGuest()) { guest.setUserPreferences(prefs); return; }
+  await setDoc(profileRef(), prefs, { merge: true });
+}

--- a/src/lib/user-preferences-types.ts
+++ b/src/lib/user-preferences-types.ts
@@ -1,0 +1,81 @@
+export type DateFormat = 'DD/MM/YYYY' | 'YYYY-MM-DD' | 'D MMM YYYY';
+export type NumberLocale = 'en-AU' | 'en-US' | 'en-GB';
+export type CurrencyDisplay = 'symbol' | 'code';
+export type Density = 'comfortable' | 'compact';
+export type Homepage = '/' | '/expenses' | '/investments' | '/cashflow' | '/tax';
+
+export interface DisplayPrefs {
+  dateFormat: DateFormat;
+  numberLocale: NumberLocale;
+  currencyDisplay: CurrencyDisplay;
+  density: Density;
+}
+
+export interface DefaultsPrefs {
+  homepage: Homepage;
+  /** 'current' resolves to the FY containing today; otherwise an explicit FY string like '2025-2026'. */
+  defaultFinancialYear: 'current' | string;
+  defaultMember?: string;
+}
+
+export interface PrivacyPrefs {
+  /** Hard kill switch for all Gemini-backed features. */
+  aiAdviceEnabled: boolean;
+  /** When true, expense descriptions are stripped from prompts (categories + amounts only). */
+  aiContextOptOut: boolean;
+}
+
+export interface UserPreferences {
+  display: DisplayPrefs;
+  defaults: DefaultsPrefs;
+  privacy: PrivacyPrefs;
+  /** Set on first completion of the wizard — kept on profile so onboarding can read it. */
+  onboardedAt?: string;
+}
+
+export const DEFAULT_PREFERENCES: UserPreferences = {
+  display: {
+    dateFormat: 'DD/MM/YYYY',
+    numberLocale: 'en-AU',
+    currencyDisplay: 'symbol',
+    density: 'comfortable',
+  },
+  defaults: {
+    homepage: '/',
+    defaultFinancialYear: 'current',
+  },
+  privacy: {
+    aiAdviceEnabled: true,
+    aiContextOptOut: false,
+  },
+};
+
+export const HOMEPAGE_OPTIONS: { value: Homepage; label: string }[] = [
+  { value: '/', label: 'Dashboard' },
+  { value: '/cashflow', label: 'Cashflow' },
+  { value: '/tax', label: 'Tax' },
+  { value: '/expenses', label: 'Expenses' },
+  { value: '/investments', label: 'Investments' },
+];
+
+export const DATE_FORMAT_OPTIONS: { value: DateFormat; label: string; example: string }[] = [
+  { value: 'DD/MM/YYYY', label: 'DD/MM/YYYY', example: '31/12/2026' },
+  { value: 'YYYY-MM-DD', label: 'YYYY-MM-DD', example: '2026-12-31' },
+  { value: 'D MMM YYYY', label: 'D MMM YYYY', example: '31 Dec 2026' },
+];
+
+export const NUMBER_LOCALE_OPTIONS: { value: NumberLocale; label: string; example: string }[] = [
+  { value: 'en-AU', label: 'Australian (1,234.56)', example: '1,234.56' },
+  { value: 'en-US', label: 'US (1,234.56)', example: '1,234.56' },
+  { value: 'en-GB', label: 'UK (1,234.56)', example: '1,234.56' },
+];
+
+/** Merge a partial pref doc with defaults, leaving unknown fields untouched. */
+export function withDefaults(partial: Partial<UserPreferences> | undefined): UserPreferences {
+  return {
+    display: { ...DEFAULT_PREFERENCES.display, ...(partial?.display || {}) },
+    defaults: { ...DEFAULT_PREFERENCES.defaults, ...(partial?.defaults || {}) },
+    privacy: { ...DEFAULT_PREFERENCES.privacy, ...(partial?.privacy || {}) },
+    onboardedAt: partial?.onboardedAt,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the user-preferences foundation referenced by issue #75 and consumed by the rest of phase 6 (#66 PWA opt-in, #71 digest reports, future onboarding flow). Persisted at `users/{email}/meta/profile`, exposed via a React context plus a synchronous module cache for non-React callers.

**Settings → Preferences (tabs)**
- **Display:** date format (DD/MM/YYYY · YYYY-MM-DD · D MMM YYYY), number locale (AU/US/GB), currency display ($ symbol vs `AUD` code), density (comfortable/compact).
- **Defaults:** post-sign-in homepage, default financial year (current or pinned), default member for new owners.
- **Privacy:** `aiAdviceEnabled` hard kill switch + `aiContextOptOut` for stripping expense descriptions from prompts.

**Plumbing**
- `formatDate` / `formatCurrency` / `formatNumber` helpers read from prefs. YYYY-MM-DD strings parse as local dates so en-AU users don't see UTC drift.
- `AuthGate` redirects post-login to `defaults.homepage` instead of hardcoded `/`.
- Dashboard initialises FY from `defaults.defaultFinancialYear`, syncing once prefs hydrate without overriding manual user changes.
- Density toggles a `density-compact` class on `document.body` so table CSS can pick it up.
- Gemini-backed callables (`taxAdvice`, `investmentsAdvice`, `expensesAdvice`, `expensesReanalyse`, `dashboardTips`, `expensesReceiptScan`) are gated by `isAiAdviceAllowed()`; they throw a typed `AiDisabledError` when off. Each payload now carries `aiContextOptOut` for the Cloud Functions to honour (server-side stripping is a follow-up).
- Guest mode mirrors the prefs doc.
- `jest.setup.ts` polyfills global `fetch` so tests transitively pulling `firebase/auth` don't crash at module eval.

**Tests**
- 16 new unit tests covering the format helpers (date styles, locale-aware currency, edge cases), the `withDefaults` merge behaviour, and the AI kill switch on `streamTaxAdvice` + `fetchDashboardTips`.
- 54 tests passing across 7 suites.

**Known follow-ups (not blocking)**
- The 80+ existing `toLocaleDateString('en-AU')` / `toLocaleString('en-AU')` call sites haven't been migrated to `formatDate` / `formatCurrency` — the helpers exist; pages can adopt incrementally.
- Server-side prompt stripping for `aiContextOptOut` is wired through the callable payload but not yet implemented in `functions/`.

Closes #75.

## Test plan

- [x] `npm test` — 54 passed, 7 suites
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <touched files>` — clean (pre-existing `any` warnings on dashboard tax-calc unchanged)
- [ ] Manual: change date format in Settings, verify Preferences panel preview updates immediately
- [ ] Manual: set Homepage to `/expenses`, sign out, sign back in, verify landing page
- [ ] Manual: toggle "AI features enabled" off, refresh dashboard, verify Dr Finance Says panel hides and Doctor pages show no Gemini call (network tab)
- [ ] Manual: switch to compact density, verify table padding tightens
- [ ] Manual: pin Default FY to a non-current year, refresh dashboard, verify FY selector starts on the pinned year

https://claude.ai/code/session_01Py1rULeKWr8z8RR5ZU6aiY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Py1rULeKWr8z8RR5ZU6aiY)_